### PR TITLE
Sync router with browser path and history

### DIFF
--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 
 export type PageType = 
   | 'home' 
@@ -23,7 +23,28 @@ interface RouterProviderProps {
 }
 
 export function RouterProvider({ children }: RouterProviderProps) {
-  const [currentPage, setCurrentPage] = useState<PageType>('home');
+  const getPageFromPath = (pathname: string): PageType => {
+    const cleanPath = pathname.startsWith('/') ? pathname.slice(1) : pathname;
+    switch (cleanPath) {
+      case '':
+      case 'home':
+        return 'home';
+      case 'web-design':
+      case 'seo':
+      case 'social-media':
+      case 'branding':
+      case 'strategy':
+      case 'service-inquiry':
+      case 'free-consultation':
+        return cleanPath as PageType;
+      default:
+        return 'home';
+    }
+  };
+
+  const [currentPage, setCurrentPage] = useState<PageType>(() =>
+    getPageFromPath(window.location.pathname)
+  );
 
   const navigateTo = (page: PageType, params?: Record<string, string>) => {
     setCurrentPage(page);
@@ -42,6 +63,16 @@ export function RouterProvider({ children }: RouterProviderProps) {
     
     window.history.pushState({}, '', url.toString());
   };
+
+  useEffect(() => {
+    const handlePopState = () => {
+      setCurrentPage(getPageFromPath(window.location.pathname));
+    };
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
 
   const getQueryParams = () => {
     return new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- read current page from `window.location.pathname`
- listen for `popstate` to keep Router in sync with browser history

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6889d788cc308323ac6d9850d6aa6c46