### PR TITLE
Fix service ID navigation

### DIFF
--- a/src/components/services/SEOPage.tsx
+++ b/src/components/services/SEOPage.tsx
@@ -152,14 +152,14 @@ export function SEOPage() {
 
   const handlePackageSelect = (packageName: string) => {
     navigateTo('service-inquiry', {
-      service: 'SEO & Google Business',
+      service: 'seo',
       package: packageName
     });
   };
 
   const handleConsultation = () => {
     navigateTo('service-inquiry', {
-      service: 'SEO & Google Business'
+      service: 'seo'
     });
   };
 

--- a/src/components/services/WebDesignPage.tsx
+++ b/src/components/services/WebDesignPage.tsx
@@ -151,14 +151,14 @@ export function WebDesignPage() {
 
   const handlePackageSelect = (packageName: string) => {
     navigateTo('service-inquiry', {
-      service: 'Web Design & Development',
+      service: 'web-design',
       package: packageName
     });
   };
 
   const handleConsultation = () => {
     navigateTo('service-inquiry', {
-      service: 'Web Design & Development'
+      service: 'web-design'
     });
   };
 


### PR DESCRIPTION
## Summary
- navigate to ServiceInquiryForm using service ID instead of title for Web Design and SEO pages

## Testing
- `npm run lint` *(fails: 36 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6889d74c769c8323be7f4b2b4cd35389