### PR TITLE
Add back text translations

### DIFF
--- a/src/components/LanguageContext.tsx
+++ b/src/components/LanguageContext.tsx
@@ -81,6 +81,9 @@ const translations = {
     'footer.company': 'Kompanija',
     'footer.contact': 'Kontakt',
     'footer.rights': 'Sva prava zadržana.',
+    // General
+    'general.back_home': 'Nazad na početnu',
+    'general.back': 'Nazad',
   },
   en: {
     // Navigation
@@ -151,6 +154,9 @@ const translations = {
     'footer.company': 'Company',
     'footer.contact': 'Contact',
     'footer.rights': 'All rights reserved.',
+    // General
+    'general.back_home': 'Back to home',
+    'general.back': 'Back',
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- extend the translations dictionary with back navigation strings

## Testing
- `npm run lint` *(fails: 24 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6889fb50278c8323a066c7fb084e08c2