### PR TITLE
Add translations for service pages

### DIFF
--- a/src/components/LanguageContext.tsx
+++ b/src/components/LanguageContext.tsx
@@ -86,6 +86,132 @@ const translations = {
     'services.strategy.feature3': 'ROI optimization',
     'services.strategy.feature4': 'Growth strategy',
 
+
+    // Service Pages - Web Design
+    'web.badge': 'Web Design & Development',
+    'web.hero.part1': 'Kreiramo',
+    'web.hero.emphasis': 'moderne web stranice',
+    'web.hero.part2': 'koje prodaju',
+    'web.hero.desc':
+      'Od ideje do realizacije - razvijamo web stranice koje kombinuju izuzetan dizajn sa funkcionalnosti koja donosi rezultate.',
+    'web.hero.cta': 'Započni projekat',
+    'web.features.heading': 'Što dobijate sa našim web stranicama',
+    'web.features.desc':
+      'Svaka web stranica koju kreiramo uključuje sve što vam je potrebno za uspeh online',
+    'web.feature.responsive': 'Responzivni dizajn',
+    'web.feature.speed': 'Optimizacija brzine',
+    'web.feature.seo': 'SEO optimizovano',
+    'web.feature.ecommerce': 'E-commerce rešenja',
+    'web.feature.design': 'Jedinstveni dizajn',
+    'web.feature.clean_code': 'Čist kod',
+    'web.process.heading': 'Naš proces rada',
+    'web.process.desc':
+      'Transparentan i strukturisan pristup koji garantuje uspeh vašeg projekta',
+    'web.pricing.heading': 'Paketi i cene',
+    'web.pricing.desc':
+      'Odaberite paket koji najbolje odgovara vašim potrebama i budžetu',
+    'web.package.starter.name': 'Starter',
+    'web.package.starter.desc': 'Idealno za manje kompanije',
+    'web.package.professional.name': 'Professional',
+    'web.package.professional.desc': 'Najpopularniji paket',
+    'web.package.enterprise.name': 'Enterprise',
+    'web.package.enterprise.desc': 'Za velike kompanije',
+    'web.portfolio.heading': 'Naši radovi',
+    'web.portfolio.desc':
+      'Pogledajte neke od web stranica koje smo kreirali za naše klijente',
+    'web.portfolio.view_more': 'Pogledaj više',
+    'web.cta.title': 'Spremni za vašu novu web stranicu?',
+    'web.cta.desc':
+      'Kontaktirajte nas danas za besplatnu konsultaciju i saznajte kako možemo transformisati vaše online prisustvo.',
+    'web.cta.primary': 'Besplatna konsultacija',
+    'web.cta.secondary': 'Pozovite nas',
+
+    // Service Pages - SEO
+    'seo.badge': 'SEO & Google Business',
+    'seo.hero.part1': 'Budite',
+    'seo.hero.emphasis': '#1 na Google',
+    'seo.hero.part2': 'pretragama',
+    'seo.hero.desc':
+      'Povećajte vidljivost vašeg biznisa u pretraživačima i osvojite više klijenata putem organskih rezultata pretrage.',
+    'seo.hero.cta': 'Besplatan SEO audit',
+    'seo.services.heading': 'Kompletna SEO usluga',
+    'seo.services.desc':
+      'Sveobuhvatan pristup SEO optimizaciji koji pokriva sve aspekte digitalnog marketinga',
+    'seo.feature.mobile': 'Mobile SEO',
+    'seo.feature.technical': 'Technical SEO',
+    'seo.results.heading': 'Rezultati koji govore',
+    'seo.results.desc':
+      'Ovi brojevi pokazuju zašto kompanije u Crnoj Gori biraju BDigital za svoj SEO',
+    'seo.pricing.heading': 'SEO paketi',
+    'seo.pricing.desc':
+      'Odaberite SEO paket koji odgovara veličini vašeg biznisa i ambicijama',
+    'seo.package.starter.name': 'Starter SEO',
+    'seo.package.starter.desc': 'Za manje kompanije',
+    'seo.package.professional.name': 'Professional SEO',
+    'seo.package.professional.desc': 'Najpopularniji paket',
+    'seo.package.enterprise.name': 'Enterprise SEO',
+    'seo.package.enterprise.desc': 'Za velike kompanije',
+    'seo.case.heading': 'Studije slučaja',
+    'seo.case.desc': 'Kako smo pomogli našim klijentima da dominiraju Google pretragama',
+    'seo.cta.title': 'Besplatan SEO audit vašeg sajta',
+    'seo.cta.desc':
+      'Saznajte šta možete poboljšati na vašoj web stranici da biste se bolje rangirali na Google pretragama.',
+    'seo.cta.primary': 'Zatražite besplatan audit',
+    'seo.cta.secondary': 'Pozovite nas',
+
+    // Service Pages - Social Media
+    'social.badge': 'Social Media Management',
+    'social.hero.title': 'Osvajajte društvene mreže',
+    'social.hero.desc':
+      'Gradimo zajednicu i povećavamo angažman kroz kreativne strategije.',
+    'social.hero.cta': 'Počnite danas',
+    'social.services.heading': 'Naše social media usluge',
+    'social.feature.instagram': 'Instagram Management',
+    'social.feature.facebook': 'Facebook Marketing',
+    'social.pricing.heading': 'Social Media paketi',
+    'social.package.starter.name': 'Starter Social',
+    'social.package.professional.name': 'Professional Social',
+    'social.package.enterprise.name': 'Enterprise Social',
+    'social.cta.title': 'Spremni za jače prisustvo na društvenim mrežama?',
+    'social.cta.desc':
+      'Kontaktirajte nas i saznajte kako možemo povećati vaše pratioce i angažman.',
+    'social.cta.primary': 'Početak saradnje',
+
+    // Service Pages - Branding
+    'branding.badge': 'Branding & Graphic Design',
+    'branding.hero.title': 'Izgradite prepoznatljiv brend',
+    'branding.hero.desc': 'Kreiramo vizuelni identitet koji ostavlja jak utisak.',
+    'branding.hero.cta': 'Početak projekta',
+    'branding.services.heading': 'Branding usluge',
+    'branding.feature.identity': 'Brand identitet',
+    'branding.pricing.heading': 'Branding paketi',
+    'branding.package.starter.name': 'Starter Branding',
+    'branding.package.professional.name': 'Professional Branding',
+    'branding.package.enterprise.name': 'Enterprise Branding',
+    'branding.cta.title': 'Spremni za novi brand identitet?',
+    'branding.cta.desc':
+      'Kontaktirajte nas i kreirajmo zajedno brand koji će vas izdvojiti od konkurencije.',
+    'branding.cta.primary': 'Konsultacija',
+
+    // Service Pages - Strategy
+    'strategy.badge': 'Strategy & Consulting',
+    'strategy.hero.emphasis': 'Strategije',
+    'strategy.hero.trailing': 'za digitalni uspeh',
+    'strategy.hero.desc':
+      'Stručne konsultacije i podrška u implementaciji strategije.',
+    'strategy.hero.cta': 'Konsultacija',
+    'strategy.services.heading': 'Konsalting usluge',
+    'strategy.feature.digital': 'Digitalna strategija',
+    'strategy.feature.consulting': 'Konsultacije',
+    'strategy.pricing.heading': 'Strategy paketi',
+    'strategy.package.starter.name': 'Starter Strategy',
+    'strategy.package.professional.name': 'Professional Strategy',
+    'strategy.package.enterprise.name': 'Enterprise Strategy',
+    'strategy.cta.title': 'Spremni za digitalnu transformaciju?',
+    'strategy.cta.desc':
+      'Zakažite besplatnu konsultaciju i saznajte kako možemo pomoći vašem biznisu.',
+    'strategy.cta.primary': 'Zakažite konsultaciju',
+
     // Portfolio
     'portfolio.title': 'Naš rad',
     'portfolio.subtitle': 'Pogledajte projekte koji su transformisali naše klijente',
@@ -129,6 +255,7 @@ const translations = {
     // General
     'general.back_home': 'Nazad na početnu',
     'general.back': 'Nazad',
+    'packages.select': 'Odaberi paket',
   },
   en: {
     // Navigation
@@ -204,6 +331,130 @@ const translations = {
     'services.strategy.feature3': 'ROI optimization',
     'services.strategy.feature4': 'Growth strategy',
 
+// Service Pages - Web Design
+    'web.badge': 'Web Design & Development',
+    'web.hero.part1': 'We create',
+    'web.hero.emphasis': 'modern websites',
+    'web.hero.part2': 'that sell',
+    'web.hero.desc':
+      'From concept to launch - we craft websites that combine amazing design with functionality that delivers results.',
+    'web.hero.cta': 'Start a project',
+    'web.features.heading': 'What you get with our websites',
+    'web.features.desc':
+      'Every website we build includes everything you need for online success',
+    'web.feature.responsive': 'Responsive design',
+    'web.feature.speed': 'Speed optimization',
+    'web.feature.seo': 'SEO optimized',
+    'web.feature.ecommerce': 'E-commerce solutions',
+    'web.feature.design': 'Unique design',
+    'web.feature.clean_code': 'Clean code',
+    'web.process.heading': 'Our process',
+    'web.process.desc':
+      'A transparent and structured approach that ensures your project succeeds',
+    'web.pricing.heading': 'Packages & pricing',
+    'web.pricing.desc':
+      'Choose the package that fits your needs and budget',
+    'web.package.starter.name': 'Starter',
+    'web.package.starter.desc': 'Ideal for small companies',
+    'web.package.professional.name': 'Professional',
+    'web.package.professional.desc': 'Most popular package',
+    'web.package.enterprise.name': 'Enterprise',
+    'web.package.enterprise.desc': 'For large companies',
+    'web.portfolio.heading': 'Our work',
+    'web.portfolio.desc':
+      "Check out some of the sites we've built for clients",
+    'web.portfolio.view_more': 'View more',
+    'web.cta.title': 'Ready for your new website?',
+    'web.cta.desc':
+      'Contact us today for a free consultation and see how we can transform your online presence.',
+    'web.cta.primary': 'Free consultation',
+    'web.cta.secondary': 'Call us',
+
+    // Service Pages - SEO
+    'seo.badge': 'SEO & Google Business',
+    'seo.hero.part1': 'Be',
+    'seo.hero.emphasis': '#1 on Google',
+    'seo.hero.part2': 'search results',
+    'seo.hero.desc':
+      'Increase your visibility in search engines and win more clients through organic search results.',
+    'seo.hero.cta': 'Free SEO audit',
+    'seo.services.heading': 'Comprehensive SEO service',
+    'seo.services.desc':
+      'A complete SEO approach covering all aspects of digital marketing',
+    'seo.feature.mobile': 'Mobile SEO',
+    'seo.feature.technical': 'Technical SEO',
+    'seo.results.heading': 'Results that speak',
+    'seo.results.desc':
+      'These numbers show why companies in Montenegro choose BDigital for SEO',
+    'seo.pricing.heading': 'SEO packages',
+    'seo.pricing.desc':
+      'Choose an SEO package that matches your business size and ambitions',
+    'seo.package.starter.name': 'Starter SEO',
+    'seo.package.starter.desc': 'For small companies',
+    'seo.package.professional.name': 'Professional SEO',
+    'seo.package.professional.desc': 'Most popular package',
+    'seo.package.enterprise.name': 'Enterprise SEO',
+    'seo.package.enterprise.desc': 'For large companies',
+    'seo.case.heading': 'Case studies',
+    'seo.case.desc': 'How we helped our clients dominate Google searches',
+    'seo.cta.title': 'Free SEO audit of your site',
+    'seo.cta.desc':
+      'Find out what you can improve on your website to rank better on Google.',
+    'seo.cta.primary': 'Request free audit',
+    'seo.cta.secondary': 'Call us',
+
+    // Service Pages - Social Media
+    'social.badge': 'Social Media Management',
+    'social.hero.title': 'Dominate social networks',
+    'social.hero.desc':
+      'We build community and boost engagement through creative strategies.',
+    'social.hero.cta': 'Start today',
+    'social.services.heading': 'Our social media services',
+    'social.feature.instagram': 'Instagram Management',
+    'social.feature.facebook': 'Facebook Marketing',
+    'social.pricing.heading': 'Social Media packages',
+    'social.package.starter.name': 'Starter Social',
+    'social.package.professional.name': 'Professional Social',
+    'social.package.enterprise.name': 'Enterprise Social',
+    'social.cta.title': 'Ready for a stronger social presence?',
+    'social.cta.desc':
+      'Contact us to learn how we can grow your followers and engagement.',
+    'social.cta.primary': 'Start cooperation',
+
+    // Service Pages - Branding
+    'branding.badge': 'Branding & Graphic Design',
+    'branding.hero.title': 'Build a recognizable brand',
+    'branding.hero.desc': 'We create a visual identity that leaves a strong impression.',
+    'branding.hero.cta': 'Start project',
+    'branding.services.heading': 'Branding services',
+    'branding.feature.identity': 'Brand identity',
+    'branding.pricing.heading': 'Branding packages',
+    'branding.package.starter.name': 'Starter Branding',
+    'branding.package.professional.name': 'Professional Branding',
+    'branding.package.enterprise.name': 'Enterprise Branding',
+    'branding.cta.title': 'Ready for a new brand identity?',
+    'branding.cta.desc':
+      'Contact us and together we’ll create a brand that sets you apart from the competition.',
+    'branding.cta.primary': 'Consultation',
+
+    // Service Pages - Strategy
+    'strategy.badge': 'Strategy & Consulting',
+    'strategy.hero.emphasis': 'Strategies',
+    'strategy.hero.trailing': 'for digital success',
+    'strategy.hero.desc':
+      'Expert consulting and support in implementing your strategy.',
+    'strategy.hero.cta': 'Consultation',
+    'strategy.services.heading': 'Consulting services',
+    'strategy.feature.digital': 'Digital strategy',
+    'strategy.feature.consulting': 'Consultations',
+    'strategy.pricing.heading': 'Strategy packages',
+    'strategy.package.starter.name': 'Starter Strategy',
+    'strategy.package.professional.name': 'Professional Strategy',
+    'strategy.package.enterprise.name': 'Enterprise Strategy',
+    'strategy.cta.title': 'Ready for digital transformation?',
+    'strategy.cta.desc':
+      'Schedule a free consultation to see how we can help your business.',
+    'strategy.cta.primary': 'Schedule consultation',
     // Portfolio
     'portfolio.title': 'Our Work',
     'portfolio.subtitle': 'See projects that transformed our clients',
@@ -247,6 +498,7 @@ const translations = {
     // General
     'general.back_home': 'Back to home',
     'general.back': 'Back',
+    'packages.select': 'Choose package',
   },
 } as const;
 

--- a/src/components/services/BrandingPage.tsx
+++ b/src/components/services/BrandingPage.tsx
@@ -20,29 +20,29 @@ export function BrandingPage() {
   const services = [
     {
       icon: Palette,
-      title: 'Logo dizajn',
+      title: t('services.branding.feature1'),
       description: 'Jedinstveni logo koji predstavlja suštinu vašeg brenda'
     },
     {
       icon: FileImage,
-      title: 'Brand identitet',
+      title: t('branding.feature.identity'),
       description: 'Kompletna vizuelna identifikacija uključujući boje, fontove i stil'
     },
     {
       icon: Type,
-      title: 'Print materijali',
+      title: t('services.branding.feature3'),
       description: 'Vizit karte, brošure, plakati i ostali print materijali'
     },
     {
       icon: Package,
-      title: 'Brand guidelines',
+      title: t('services.branding.feature2'),
       description: 'Detaljno uputstvo za korišćenje brenda u svim situacijama'
     }
   ];
 
   const packages = [
     {
-      name: 'Starter Branding',
+      name: t('branding.package.starter.name'),
       price: '500 €',
       features: [
         'Logo dizajn',
@@ -53,7 +53,7 @@ export function BrandingPage() {
       ]
     },
     {
-      name: 'Professional Branding',
+      name: t('branding.package.professional.name'),
       price: '900 €',
       features: [
         'Kompletan vizuelni identitet',
@@ -65,7 +65,7 @@ export function BrandingPage() {
       popular: true
     },
     {
-      name: 'Enterprise Branding',
+      name: t('branding.package.enterprise.name'),
       price: '1.500 €+',
       features: [
         'Strategija brenda',
@@ -98,7 +98,7 @@ export function BrandingPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div className="text-white">
               <Badge className="bg-bdigital-cyan/20 text-bdigital-cyan border-bdigital-cyan mb-4">
-                Branding & Graphic Design
+                {t('branding.badge')}
               </Badge>
               <h1 className="text-4xl md:text-5xl font-bold mb-6 leading-tight">
                 {t('branding.hero.title')}
@@ -108,12 +108,12 @@ export function BrandingPage() {
               </p>
               
               <div className="flex flex-col sm:flex-row gap-4 mb-8">
-                <Button 
+                <Button
                   size="lg"
                   className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light px-8 py-3 font-semibold"
                   onClick={handleConsultation}
                 >
-                  Početak projekta
+                  {t('branding.hero.cta')}
                   <ArrowRight className="ml-2 h-5 w-5" />
                 </Button>
                 <Button 
@@ -145,7 +145,7 @@ export function BrandingPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-              Branding usluge
+              {t('branding.services.heading')}
             </h2>
           </div>
 
@@ -173,7 +173,7 @@ export function BrandingPage() {
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="text-center mb-16">
               <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-                Branding paketi
+                {t('branding.pricing.heading')}
               </h2>
             </div>
 
@@ -208,7 +208,7 @@ export function BrandingPage() {
                       variant={pkg.popular ? 'default' : 'outline'}
                       onClick={() => handlePackageSelect(pkg.name)}
                     >
-                      Odaberi paket
+                      {t('packages.select')}
                     </Button>
                   </CardContent>
                 </Card>
@@ -221,17 +221,17 @@ export function BrandingPage() {
       <section className="py-20 bg-gradient-to-r from-bdigital-navy to-bdigital-dark-navy text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl md:text-4xl font-bold mb-4">
-            Spremni za novi brand identitet?
+            {t('branding.cta.title')}
           </h2>
           <p className="text-gray-300 text-lg mb-8 max-w-2xl mx-auto">
-            Kontaktirajte nas i kreirajmo zajedno brand koji će vas izdvojiti od konkurencije.
+            {t('branding.cta.desc')}
           </p>
-          <Button 
+          <Button
             size="lg"
             className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light px-8 py-3 font-semibold"
             onClick={handleConsultation}
           >
-            Konsultacija
+            {t('branding.cta.primary')}
           </Button>
         </div>
       </section>

--- a/src/components/services/SEOPage.tsx
+++ b/src/components/services/SEOPage.tsx
@@ -24,32 +24,32 @@ export function SEOPage() {
   const services = [
     {
       icon: Search,
-      title: 'Keyword Research',
+      title: t('services.seo.feature1'),
       description: 'Detaljno istraživanje ključnih reči za vašu industriju i lokalno tržište'
     },
     {
       icon: TrendingUp,
-      title: 'On-Page SEO',
+      title: t('services.seo.feature2'),
       description: 'Optimizacija sadržaja, meta tagova i tehnička poboljšanja'
     },
     {
       icon: MapPin,
-      title: 'Lokalni SEO',
+      title: t('services.seo.feature3'),
       description: 'Google My Business optimizacija za lokalne pretrage u Crnoj Gori'
     },
     {
       icon: BarChart3,
-      title: 'SEO analitika',
+      title: t('services.seo.feature4'),
       description: 'Detaljni mesečni izveštaji o napretku i performansama'
     },
     {
       icon: Smartphone,
-      title: 'Mobile SEO',
+      title: t('seo.feature.mobile'),
       description: 'Optimizacija za mobilne pretraživače i glasovne pretrage'
     },
     {
       icon: Globe,
-      title: 'Technical SEO',
+      title: t('seo.feature.technical'),
       description: 'Brzina sajta, Core Web Vitals i strukturirani podatci'
     }
   ];
@@ -79,9 +79,9 @@ export function SEOPage() {
 
   const packages = [
     {
-      name: 'Starter SEO',
+      name: t('seo.package.starter.name'),
       price: '500 €/mes',
-      description: 'Za manje kompanije',
+      description: t('seo.package.starter.desc'),
       features: [
         'Keyword research (20 KW)',
         'On-page optimizacija',
@@ -92,9 +92,9 @@ export function SEOPage() {
       popular: false
     },
     {
-      name: 'Professional SEO',
+      name: t('seo.package.professional.name'),
       price: '800 €/mes',
-      description: 'Najpopularniji paket',
+      description: t('seo.package.professional.desc'),
       features: [
         'Keyword research (50 KW)',
         'Kompletna on-page optimizacija',
@@ -106,9 +106,9 @@ export function SEOPage() {
       popular: true
     },
     {
-      name: 'Enterprise SEO',
+      name: t('seo.package.enterprise.name'),
       price: '1.500 €/mes',
-      description: 'Za velike kompanije',
+      description: t('seo.package.enterprise.desc'),
       features: [
         'Unlimited keyword research',
         'Tehnička SEO auditacija',
@@ -169,22 +169,24 @@ export function SEOPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div className="text-white">
               <Badge className="bg-bdigital-cyan/20 text-bdigital-cyan border-bdigital-cyan mb-4">
-                SEO & Google Business
+                {t('seo.badge')}
               </Badge>
               <h1 className="text-4xl md:text-5xl font-bold mb-6 leading-tight">
-                Budite <span className="text-bdigital-cyan">#1 na Google</span> pretragama
+                {t('seo.hero.part1')}{' '}
+                <span className="text-bdigital-cyan">{t('seo.hero.emphasis')}</span>{' '}
+                {t('seo.hero.part2')}
               </h1>
               <p className="text-gray-300 text-lg mb-8 leading-relaxed">
-                Povećajte vidljivost vašeg biznisa u pretraživačima i osvojite više klijenata putem organskih rezultata pretrage.
+                {t('seo.hero.desc')}
               </p>
               
               <div className="flex flex-col sm:flex-row gap-4 mb-8">
-                <Button 
+                <Button
                   size="lg"
                   className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light px-8 py-3 font-semibold"
                   onClick={handleConsultation}
                 >
-                  Besplatan SEO audit
+                  {t('seo.hero.cta')}
                   <ArrowRight className="ml-2 h-5 w-5" />
                 </Button>
                 <Button 
@@ -236,10 +238,10 @@ export function SEOPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-              Kompletna SEO usluga
+              {t('seo.services.heading')}
             </h2>
             <p className="text-lg text-neutral-gray max-w-2xl mx-auto">
-              Sveobuhvatan pristup SEO optimizaciji koji pokriva sve aspekte digitalnog marketinga
+              {t('seo.services.desc')}
             </p>
           </div>
 
@@ -267,10 +269,10 @@ export function SEOPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-              Rezultati koji govore
+              {t('seo.results.heading')}
             </h2>
             <p className="text-lg text-neutral-gray max-w-2xl mx-auto">
-              Ovi brojevi pokazuju zašto kompanije u Crnoj Gori biraju BDigital za svoj SEO
+              {t('seo.results.desc')}
             </p>
           </div>
 
@@ -295,10 +297,10 @@ export function SEOPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-              SEO paketi
+              {t('seo.pricing.heading')}
             </h2>
             <p className="text-lg text-neutral-gray max-w-2xl mx-auto">
-              Odaberite SEO paket koji odgovara veličini vašeg biznisa i ambicijama
+              {t('seo.pricing.desc')}
             </p>
           </div>
 
@@ -326,12 +328,12 @@ export function SEOPage() {
                       </li>
                     ))}
                   </ul>
-                  <Button 
+                  <Button
                     className={`w-full ${pkg.popular ? 'bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light' : 'border border-bdigital-cyan text-bdigital-cyan hover:bg-bdigital-cyan hover:text-bdigital-navy'} font-semibold`}
                     variant={pkg.popular ? 'default' : 'outline'}
                     onClick={() => handlePackageSelect(pkg.name)}
                   >
-                    Odaberi paket
+                    {t('packages.select')}
                   </Button>
                 </CardContent>
               </Card>
@@ -345,10 +347,10 @@ export function SEOPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-              Studije slučaja
+              {t('seo.case.heading')}
             </h2>
             <p className="text-lg text-neutral-gray max-w-2xl mx-auto">
-              Kako smo pomogli našim klijentima da dominiraju Google pretragama
+              {t('seo.case.desc')}
             </p>
           </div>
 
@@ -403,26 +405,26 @@ export function SEOPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <Award className="h-16 w-16 text-bdigital-cyan mx-auto mb-6" />
           <h2 className="text-3xl md:text-4xl font-bold mb-4">
-            Besplatan SEO audit vašeg sajta
+            {t('seo.cta.title')}
           </h2>
           <p className="text-gray-300 text-lg mb-8 max-w-2xl mx-auto">
-            Saznajte šta možete poboljšati na vašoj web stranici da biste se bolje rangirali na Google pretragama.
+            {t('seo.cta.desc')}
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button 
+            <Button
               size="lg"
               className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light px-8 py-3 font-semibold"
               onClick={handleConsultation}
             >
-              Zatražite besplatan audit
+              {t('seo.cta.primary')}
             </Button>
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               size="lg"
               className="border-bdigital-cyan text-bdigital-cyan hover:bg-bdigital-cyan hover:text-bdigital-navy px-8 py-3 font-semibold"
               onClick={handleConsultation}
             >
-              Pozovite nas
+              {t('seo.cta.secondary')}
             </Button>
           </div>
         </div>

--- a/src/components/services/SocialMediaPage.tsx
+++ b/src/components/services/SocialMediaPage.tsx
@@ -20,29 +20,29 @@ export function SocialMediaPage() {
   const services = [
     {
       icon: Instagram,
-      title: 'Instagram Management',
+      title: t('social.feature.instagram'),
       description: 'Kreiranje sadržaja, stories, reels i interakcija sa vašom publikom'
     },
     {
       icon: Facebook,
-      title: 'Facebook Marketing',
+      title: t('social.feature.facebook'),
       description: 'Facebook stranice, grupe, Facebook Ads i community management'
     },
     {
       icon: Camera,
-      title: 'Content Creation',
+      title: t('services.social.feature1'),
       description: 'Profesionalne fotografije, video sadržaj i grafički dizajn'
     },
     {
       icon: TrendingUp,
-      title: 'Social Media Ads',
+      title: t('services.social.feature3'),
       description: 'Plaćene reklame na svim društvenim mrežama sa ciljanim publikom'
     }
   ];
 
   const packages = [
     {
-      name: 'Starter Social',
+      name: t('social.package.starter.name'),
       price: '800 €/mes',
       features: [
         '10 postova mesečno',
@@ -52,7 +52,7 @@ export function SocialMediaPage() {
       ]
     },
     {
-      name: 'Professional Social',
+      name: t('social.package.professional.name'),
       price: '1.200 €/mes',
       features: [
         '20 postova mesečno',
@@ -64,7 +64,7 @@ export function SocialMediaPage() {
       popular: true
     },
     {
-      name: 'Enterprise Social',
+      name: t('social.package.enterprise.name'),
       price: '2.000 €/mes',
       features: [
         'Unlimited posts',
@@ -96,7 +96,7 @@ export function SocialMediaPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div className="text-white">
               <Badge className="bg-bdigital-cyan/20 text-bdigital-cyan border-bdigital-cyan mb-4">
-                Social Media Management
+                {t('social.badge')}
               </Badge>
               <h1 className="text-4xl md:text-5xl font-bold mb-6 leading-tight">
                 {t('social.hero.title')}
@@ -106,12 +106,12 @@ export function SocialMediaPage() {
               </p>
               
               <div className="flex flex-col sm:flex-row gap-4 mb-8">
-                <Button 
+                <Button
                   size="lg"
                   className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light px-8 py-3 font-semibold"
                   onClick={handleConsultation}
                 >
-                  Počnite danas
+                  {t('social.hero.cta')}
                   <ArrowRight className="ml-2 h-5 w-5" />
                 </Button>
                 <Button 
@@ -143,7 +143,7 @@ export function SocialMediaPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-              Naše social media usluge
+              {t('social.services.heading')}
             </h2>
           </div>
 
@@ -171,7 +171,7 @@ export function SocialMediaPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-              Social Media paketi
+              {t('social.pricing.heading')}
             </h2>
           </div>
 
@@ -198,12 +198,12 @@ export function SocialMediaPage() {
                       </li>
                     ))}
                   </ul>
-                  <Button 
+                  <Button
                     className={`w-full ${pkg.popular ? 'bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light' : 'border border-bdigital-cyan text-bdigital-cyan hover:bg-bdigital-cyan hover:text-bdigital-navy'} font-semibold`}
                     variant={pkg.popular ? 'default' : 'outline'}
                     onClick={() => handlePackageSelect(pkg.name)}
                   >
-                    Odaberi paket
+                    {t('packages.select')}
                   </Button>
                 </CardContent>
               </Card>
@@ -216,17 +216,17 @@ export function SocialMediaPage() {
       <section className="py-20 bg-gradient-to-r from-bdigital-navy to-bdigital-dark-navy text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl md:text-4xl font-bold mb-4">
-            Spremni za jače prisustvo na društvenim mrežama?
+            {t('social.cta.title')}
           </h2>
           <p className="text-gray-300 text-lg mb-8 max-w-2xl mx-auto">
-            Kontaktirajte nas i saznajte kako možemo povećati vaše pratioce i angažman.
+            {t('social.cta.desc')}
           </p>
-          <Button 
+          <Button
             size="lg"
             className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light px-8 py-3 font-semibold"
             onClick={handleConsultation}
           >
-            Početak saradnje
+            {t('social.cta.primary')}
           </Button>
         </div>
       </section>

--- a/src/components/services/StrategyPage.tsx
+++ b/src/components/services/StrategyPage.tsx
@@ -20,29 +20,29 @@ export function StrategyPage() {
   const services = [
     {
       icon: TrendingUp,
-      title: 'Digitalna strategija',
+      title: t('strategy.feature.digital'),
       description: 'Kompletna digitalna strategija usmerena na vaše poslovne ciljeve'
     },
     {
       icon: Target,
-      title: 'Konkurentska analiza',
+      title: t('services.strategy.feature2'),
       description: 'Detaljna analiza konkurencije i mogućnosti na tržištu'
     },
     {
       icon: BarChart3,
-      title: 'ROI optimizacija',
+      title: t('services.strategy.feature3'),
       description: 'Maksimiziranje povrata na investiciju u digitalni marketing'
     },
     {
       icon: Users,
-      title: 'Konsultacije',
+      title: t('strategy.feature.consulting'),
       description: 'Stručne konsultacije i podrška u implementaciji strategije'
     }
   ];
 
   const packages = [
     {
-      name: 'Starter Strategy',
+      name: t('strategy.package.starter.name'),
       price: '600 €',
       features: [
         'Audit poslovanja',
@@ -53,7 +53,7 @@ export function StrategyPage() {
       ]
     },
     {
-      name: 'Professional Strategy',
+      name: t('strategy.package.professional.name'),
       price: '1.100 €',
       features: [
         'Detaljna strategija rasta',
@@ -65,7 +65,7 @@ export function StrategyPage() {
       popular: true
     },
     {
-      name: 'Enterprise Strategy',
+      name: t('strategy.package.enterprise.name'),
       price: '2.000 €+',
       features: [
         'Sveobuhvatna transformacija',
@@ -98,22 +98,22 @@ export function StrategyPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div className="text-white">
               <Badge className="bg-bdigital-cyan/20 text-bdigital-cyan border-bdigital-cyan mb-4">
-                Strategy & Consulting
+                {t('strategy.badge')}
               </Badge>
               <h1 className="text-4xl md:text-5xl font-bold mb-6 leading-tight">
-                <span className="text-bdigital-cyan">Strategije</span> za digitalni uspeh
+                <span className="text-bdigital-cyan">{t('strategy.hero.emphasis')}</span>{' '}{t('strategy.hero.trailing')}
               </h1>
               <p className="text-gray-300 text-lg mb-8 leading-relaxed">
                 {t('strategy.hero.desc')}
               </p>
               
               <div className="flex flex-col sm:flex-row gap-4 mb-8">
-                <Button 
+                <Button
                   size="lg"
                   className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light px-8 py-3 font-semibold"
                   onClick={handleConsultation}
                 >
-                  Konsultacija
+                  {t('strategy.hero.cta')}
                   <ArrowRight className="ml-2 h-5 w-5" />
                 </Button>
                 <Button 
@@ -145,7 +145,7 @@ export function StrategyPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-              Konsalting usluge
+              {t('strategy.services.heading')}
             </h2>
           </div>
 
@@ -173,7 +173,7 @@ export function StrategyPage() {
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="text-center mb-16">
               <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-                Strategy paketi
+                {t('strategy.pricing.heading')}
               </h2>
             </div>
 
@@ -208,7 +208,7 @@ export function StrategyPage() {
                       variant={pkg.popular ? 'default' : 'outline'}
                       onClick={() => handlePackageSelect(pkg.name)}
                     >
-                      Odaberi paket
+                      {t('packages.select')}
                     </Button>
                   </CardContent>
                 </Card>
@@ -221,17 +221,17 @@ export function StrategyPage() {
       <section className="py-20 bg-gradient-to-r from-bdigital-navy to-bdigital-dark-navy text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl md:text-4xl font-bold mb-4">
-            Spremni za digitalnu transformaciju?
+            {t('strategy.cta.title')}
           </h2>
           <p className="text-gray-300 text-lg mb-8 max-w-2xl mx-auto">
-            Zakažite besplatnu konsultaciju i saznajte kako možemo pomoći vašem biznisu.
+            {t('strategy.cta.desc')}
           </p>
-          <Button 
+          <Button
             size="lg"
             className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light px-8 py-3 font-semibold"
             onClick={handleConsultation}
           >
-            Zakažite konsultaciju
+            {t('strategy.cta.primary')}
           </Button>
         </div>
       </section>

--- a/src/components/services/WebDesignPage.tsx
+++ b/src/components/services/WebDesignPage.tsx
@@ -23,32 +23,32 @@ export function WebDesignPage() {
   const features = [
     {
       icon: Monitor,
-      title: 'Responzivni dizajn',
+      title: t('web.feature.responsive'),
       description: 'Web stranice koje savršeno rade na svim uređajima - desktop, tablet i mobilni'
     },
     {
       icon: Zap,
-      title: 'Optimizacija brzine',
+      title: t('web.feature.speed'),
       description: 'Optimizujemo svaku stranicu za maksimalnu brzinu učitavanja'
     },
     {
       icon: Search,
-      title: 'SEO optimizovano',
+      title: t('web.feature.seo'),
       description: 'Izgrađeno za pretraživače od prvog dana'
     },
     {
       icon: ShoppingCart,
-      title: 'E-commerce rešenja',
+      title: t('web.feature.ecommerce'),
       description: 'Kompletan online shop sa payment gateway integracijom'
     },
     {
       icon: Palette,
-      title: 'Jedinstveni dizajn',
+      title: t('web.feature.design'),
       description: 'Kreativni dizajni koji odražavaju identitet vašeg brenda'
     },
     {
       icon: Code,
-      title: 'Čist kod',
+      title: t('web.feature.clean_code'),
       description: 'Moderan, maintainable kod koji prati najbolje prakse'
     }
   ];
@@ -82,9 +82,9 @@ export function WebDesignPage() {
 
   const packages = [
     {
-      name: 'Starter',
+      name: t('web.package.starter.name'),
       price: '1.200 €',
-      description: 'Idealno za manje kompanije',
+      description: t('web.package.starter.desc'),
       features: [
         'Do 5 stranica',
         'Responzivni dizajn', 
@@ -95,9 +95,9 @@ export function WebDesignPage() {
       popular: false
     },
     {
-      name: 'Professional', 
+      name: t('web.package.professional.name'),
       price: '2.500 €',
-      description: 'Najpopularniji paket',
+      description: t('web.package.professional.desc'),
       features: [
         'Do 15 stranica',
         'Custom dizajn',
@@ -109,9 +109,9 @@ export function WebDesignPage() {
       popular: true
     },
     {
-      name: 'Enterprise',
+      name: t('web.package.enterprise.name'),
       price: '5.000 €+',
-      description: 'Za velike kompanije',
+      description: t('web.package.enterprise.desc'),
       features: [
         'Neograničen broj stranica',
         'E-commerce funkcionalnost',
@@ -166,22 +166,24 @@ export function WebDesignPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div className="text-white">
               <Badge className="bg-bdigital-cyan/20 text-bdigital-cyan border-bdigital-cyan mb-4">
-                Web Design & Development
+                {t('web.badge')}
               </Badge>
               <h1 className="text-4xl md:text-5xl font-bold mb-6 leading-tight">
-                Kreiramo <span className="text-bdigital-cyan">moderne web stranice</span> koje prodaju
+                {t('web.hero.part1')}{' '}
+                <span className="text-bdigital-cyan">{t('web.hero.emphasis')}</span>{' '}
+                {t('web.hero.part2')}
               </h1>
               <p className="text-gray-300 text-lg mb-8 leading-relaxed">
-                Od ideje do realizacije - razvijamo web stranice koje kombinuju izuzetan dizajn sa funkcionalnosti koja donosi rezultate.
+                {t('web.hero.desc')}
               </p>
               
               <div className="flex flex-col sm:flex-row gap-4 mb-8">
-                <Button 
+                <Button
                   size="lg"
                   className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light px-8 py-3 font-semibold"
                   onClick={handleConsultation}
                 >
-                  Započni projekat
+                  {t('web.hero.cta')}
                   <ArrowRight className="ml-2 h-5 w-5" />
                 </Button>
                 <Button 
@@ -229,10 +231,10 @@ export function WebDesignPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-              Što dobijate sa našim web stranicama
+              {t('web.features.heading')}
             </h2>
             <p className="text-lg text-neutral-gray max-w-2xl mx-auto">
-              Svaka web stranica koju kreiramo uključuje sve što vam je potrebno za uspeh online
+              {t('web.features.desc')}
             </p>
           </div>
 
@@ -260,10 +262,10 @@ export function WebDesignPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-              Naš proces rada
+              {t('web.process.heading')}
             </h2>
             <p className="text-lg text-neutral-gray max-w-2xl mx-auto">
-              Transparentan i strukturisan pristup koji garantuje uspeh vašeg projekta
+              {t('web.process.desc')}
             </p>
           </div>
 
@@ -296,10 +298,10 @@ export function WebDesignPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-              Paketi i cene
+              {t('web.pricing.heading')}
             </h2>
             <p className="text-lg text-neutral-gray max-w-2xl mx-auto">
-              Odaberite paket koji najbolje odgovara vašim potrebama i budžetu
+              {t('web.pricing.desc')}
             </p>
           </div>
 
@@ -327,12 +329,12 @@ export function WebDesignPage() {
                       </li>
                     ))}
                   </ul>
-                  <Button 
+                  <Button
                     className={`w-full ${pkg.popular ? 'bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light' : 'border border-bdigital-cyan text-bdigital-cyan hover:bg-bdigital-cyan hover:text-bdigital-navy'} font-semibold`}
                     variant={pkg.popular ? 'default' : 'outline'}
                     onClick={() => handlePackageSelect(pkg.name)}
                   >
-                    Odaberi paket
+                    {t('packages.select')}
                   </Button>
                 </CardContent>
               </Card>
@@ -346,10 +348,10 @@ export function WebDesignPage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-bold text-bdigital-navy mb-4">
-              Naši radovi
+              {t('web.portfolio.heading')}
             </h2>
             <p className="text-lg text-neutral-gray max-w-2xl mx-auto">
-              Pogledajte neke od web stranica koje smo kreirali za naše klijente
+              {t('web.portfolio.desc')}
             </p>
           </div>
 
@@ -363,11 +365,11 @@ export function WebDesignPage() {
                     className="w-full h-48 object-cover transition-transform duration-500 group-hover:scale-110"
                   />
                   <div className="absolute inset-0 bg-bdigital-navy/80 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center">
-                    <Button 
-                      variant="outline" 
+                    <Button
+                      variant="outline"
                       className="border-white text-white hover:bg-white hover:text-bdigital-navy"
                     >
-                      Pogledaj više
+                      {t('web.portfolio.view_more')}
                     </Button>
                   </div>
                 </div>
@@ -388,26 +390,26 @@ export function WebDesignPage() {
       <section className="py-20 bg-gradient-to-r from-bdigital-navy to-bdigital-dark-navy text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl md:text-4xl font-bold mb-4">
-            Spremni za vašu novu web stranicu?
+            {t('web.cta.title')}
           </h2>
           <p className="text-gray-300 text-lg mb-8 max-w-2xl mx-auto">
-            Kontaktirajte nas danas za besplatnu konsultaciju i saznajte kako možemo transformisati vaše online prisustvo.
+            {t('web.cta.desc')}
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button 
+            <Button
               size="lg"
               className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light px-8 py-3 font-semibold"
               onClick={handleConsultation}
             >
-              Besplatna konsultacija
+              {t('web.cta.primary')}
             </Button>
-            <Button 
-              variant="outline" 
+            <Button
+              variant="outline"
               size="lg"
               className="border-bdigital-cyan text-bdigital-cyan hover:bg-bdigital-cyan hover:text-bdigital-navy px-8 py-3 font-semibold"
               onClick={handleConsultation}
             >
-              Pozovite nas
+              {t('web.cta.secondary')}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- internationalize service pages
- add many translation keys in `LanguageContext`

## Testing
- `npm run lint` *(fails: Unexpected any and refresh errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a031b0ed483239ad7719331a73f21