### PR TITLE
Add translation lookups

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -28,10 +28,10 @@ export function AboutSection() {
   ];
 
   const stats = [
-    { icon: Users, number: '50+', label: 'Zadovoljnih klijenata' },
-    { icon: Award, number: '100+', label: 'Završenih projekata' },
-    { icon: Clock, number: '3+', label: 'Godine iskustva' },
-    { icon: Target, number: '98%', label: 'Stopa uspešnosti' }
+    { icon: Users, number: '50+', label: t('about.stats.clients') },
+    { icon: Award, number: '100+', label: t('about.stats.projects') },
+    { icon: Clock, number: '3+', label: t('about.stats.years') },
+    { icon: Target, number: '98%', label: t('about.stats.success_rate') }
   ];
 
   const team = [
@@ -100,9 +100,11 @@ export function AboutSection() {
         {/* Stats Section */}
         <div className="bg-gradient-to-r from-bdigital-navy to-bdigital-dark-navy rounded-2xl p-8 md:p-12 mb-20 text-white">
           <div className="text-center mb-12">
-            <h3 className="text-2xl md:text-3xl font-bold mb-4">Brojevi govore sami za sebe</h3>
+            <h3 className="text-2xl md:text-3xl font-bold mb-4">
+              {t('about.stats.title')}
+            </h3>
             <p className="text-gray-300 max-w-2xl mx-auto">
-              Naši rezultati su dokaz posvećenosti kvalitetu i uspešnosti naših klijenata.
+              {t('about.stats.subtitle')}
             </p>
           </div>
           
@@ -124,9 +126,11 @@ export function AboutSection() {
 
         {/* Team Section */}
         <div className="text-center mb-16">
-          <h3 className="text-2xl md:text-3xl font-bold text-bdigital-navy mb-4">Naš tim</h3>
+          <h3 className="text-2xl md:text-3xl font-bold text-bdigital-navy mb-4">
+            {t('about.team.title')}
+          </h3>
           <p className="text-lg text-neutral-gray max-w-2xl mx-auto">
-            Upoznajte kreativne umove iza BDigital-a koji stvaraju digitalna rešenja.
+            {t('about.team.subtitle')}
           </p>
         </div>
 
@@ -152,17 +156,17 @@ export function AboutSection() {
         {/* CTA Section */}
         <div className="text-center bg-gray-50 rounded-2xl p-8 md:p-12">
           <h3 className="text-2xl md:text-3xl font-bold text-bdigital-navy mb-4">
-            Spremni da radimo zajedno?
+            {t('about.cta.title')}
           </h3>
           <p className="text-neutral-gray mb-8 max-w-2xl mx-auto">
-            Pridružite se kompanijama koje su odabrale BDigital kao svog partnera za digitalni uspeh.
+            {t('about.cta.desc')}
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <button className="bg-bdigital-cyan text-bdigital-navy px-8 py-3 rounded-lg font-semibold hover:bg-bdigital-cyan-light transition-colors">
-              Kontaktirajte nas
+              {t('about.cta.primary')}
             </button>
             <button className="border border-bdigital-cyan text-bdigital-cyan px-8 py-3 rounded-lg font-semibold hover:bg-bdigital-cyan hover:text-bdigital-navy transition-colors">
-              Pogledajte naš rad
+              {t('about.cta.secondary')}
             </button>
           </div>
         </div>

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -91,10 +91,10 @@ export function ContactSection() {
   ];
 
   const stats = [
-    { value: '24h', label: 'Vreme odgovora' },
-    { value: '100%', label: 'Zadovoljni klijenti' },
-    { value: '24/7', label: 'Email podrška' },
-    { value: '5+', label: 'Godina iskustva' }
+    { value: '24h', label: _t('contact.stats.response') },
+    { value: '100%', label: _t('contact.stats.clients') },
+    { value: '24/7', label: _t('contact.stats.support') },
+    { value: '5+', label: _t('contact.stats.years') }
   ];
 
   return (
@@ -103,13 +103,13 @@ export function ContactSection() {
         {/* Section Header */}
         <div className="text-center mb-12 lg:mb-16">
           <Badge className="bg-bdigital-cyan/10 text-bdigital-cyan border-bdigital-cyan/20 mb-4 px-4 py-2">
-            Kontakt
+            {_t('contact.badge')}
           </Badge>
           <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-bdigital-navy mb-4 lg:mb-6">
-            Započnimo <span className="text-bdigital-cyan">razgovor</span>
+            {_t('contact.heading.part1')} <span className="text-bdigital-cyan">{_t('contact.heading.emphasis')}</span>
           </h2>
           <p className="text-lg lg:text-xl text-neutral-gray max-w-3xl mx-auto leading-relaxed">
-            Spremi ste da transformišete svoj biznis? Kontaktirajte nas danas za besplatnu konsultaciju i saznajte kako možemo pomoći.
+            {_t('contact.description')}
           </p>
         </div>
 
@@ -120,7 +120,7 @@ export function ContactSection() {
               <div className="flex items-center mb-6">
                 <MessageSquare className="h-6 w-6 text-bdigital-cyan mr-3" />
                 <h3 className="text-xl lg:text-2xl font-bold text-bdigital-navy">
-                  Pošaljite nam poruku
+                  {_t('contact.form.title')}
                 </h3>
               </div>
               
@@ -130,10 +130,10 @@ export function ContactSection() {
                     <CheckCircle className="h-8 w-8 text-green-600" />
                   </div>
                   <h4 className="text-lg font-semibold text-bdigital-navy mb-2">
-                    Poruka je uspešno poslata!
+                    {_t('contact.success.title')}
                   </h4>
                   <p className="text-neutral-gray">
-                    Kontaktiraćemo vas u najkraćem mogućem roku.
+                    {_t('contact.success.desc')}
                   </p>
                 </div>
               ) : (
@@ -142,7 +142,7 @@ export function ContactSection() {
                     <div>
                       <label className="flex items-center text-sm font-medium text-bdigital-navy mb-2">
                         <User className="h-4 w-4 mr-2" />
-                        Ime i prezime *
+                        {_t('contact.name')} *
                       </label>
                       <Input
                         type="text"
@@ -156,7 +156,7 @@ export function ContactSection() {
                     <div>
                       <label className="flex items-center text-sm font-medium text-bdigital-navy mb-2">
                         <Mail className="h-4 w-4 mr-2" />
-                        Email *
+                        {_t('contact.email')} *
                       </label>
                       <Input
                         type="email"
@@ -173,7 +173,7 @@ export function ContactSection() {
                     <div>
                       <label className="flex items-center text-sm font-medium text-bdigital-navy mb-2">
                         <Building className="h-4 w-4 mr-2" />
-                        Kompanija
+                        {_t('contact.company')}
                       </label>
                       <Input
                         type="text"
@@ -186,7 +186,7 @@ export function ContactSection() {
                     <div>
                       <label className="flex items-center text-sm font-medium text-bdigital-navy mb-2">
                         <Phone className="h-4 w-4 mr-2" />
-                        Telefon
+                        {_t('contact.phone')}
                       </label>
                       <Input
                         type="tel"
@@ -201,7 +201,7 @@ export function ContactSection() {
                   <div>
                     <label className="flex items-center text-sm font-medium text-bdigital-navy mb-2">
                       <MessageSquare className="h-4 w-4 mr-2" />
-                      Poruka *
+                        {_t('contact.message')} *
                     </label>
                     <Textarea
                       value={formData.message}
@@ -220,12 +220,12 @@ export function ContactSection() {
                     {isSubmitting ? (
                       <>
                         <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-bdigital-navy mr-2"></div>
-                        Šalje se...
+                        {_t('contact.sending')}
                       </>
                     ) : (
                       <>
                         <Send className="h-5 w-5 mr-2" />
-                        Pošaljite poruku
+                        {_t('contact.send')}
                       </>
                     )}
                   </Button>
@@ -272,7 +272,8 @@ export function ContactSection() {
             <Card className="border-0 shadow-xl bg-gradient-to-r from-bdigital-navy to-bdigital-dark-navy text-white">
               <CardContent className="p-6 lg:p-8">
                 <h4 className="text-xl font-bold mb-6 text-center">
-                  Zašto klijenti biraju <span className="text-bdigital-cyan">nas</span>
+                  {_t('contact.stats.title.pre')}{' '}
+                  <span className="text-bdigital-cyan">{_t('contact.stats.title.emphasis')}</span>
                 </h4>
                 <div className="grid grid-cols-2 gap-4 lg:gap-6">
                   {stats.map((stat, index) => (
@@ -291,23 +292,23 @@ export function ContactSection() {
             <Card className="border-0 shadow-xl">
               <CardContent className="p-6 lg:p-8">
                 <h4 className="text-xl font-bold text-bdigital-navy mb-4">
-                  Zakazivanje sastanka
+                  {_t('contact.meeting.title')}
                 </h4>
                 <p className="text-neutral-gray mb-4">
-                  Preferirate lični razgovor? Možemo se sresti u našoj kancelariji u Podgorici ili bilo gde što vama odgovara.
+                  {_t('contact.meeting.desc')}
                 </p>
                 <div className="space-y-3">
                   <div className="flex items-center text-sm">
                     <Clock className="h-4 w-4 text-bdigital-cyan mr-2" />
-                    <span className="text-neutral-gray">Fleksibilno vreme sastanka</span>
+                    <span className="text-neutral-gray">{_t('contact.meeting.flexible')}</span>
                   </div>
                   <div className="flex items-center text-sm">
                     <MapPin className="h-4 w-4 text-bdigital-cyan mr-2" />
-                    <span className="text-neutral-gray">Lokacija po vašoj želji</span>
+                    <span className="text-neutral-gray">{_t('contact.meeting.location')}</span>
                   </div>
                   <div className="flex items-center text-sm">
                     <CheckCircle className="h-4 w-4 text-bdigital-cyan mr-2" />
-                    <span className="text-neutral-gray">Besplatna konsultacija</span>
+                    <span className="text-neutral-gray">{_t('contact.meeting.free')}</span>
                   </div>
                 </div>
               </CardContent>

--- a/src/components/LanguageContext.tsx
+++ b/src/components/LanguageContext.tsx
@@ -220,6 +220,22 @@ const translations = {
     'portfolio.seo': 'SEO projekti',
     'portfolio.social': 'Društvene mreže',
     'portfolio.branding': 'Brendiranje',
+    'portfolio.badge': 'Portfolio',
+    'portfolio.heading.part1': 'Naši',
+    'portfolio.heading.emphasis': 'uspešni',
+    'portfolio.heading.part2': 'projekti',
+    'portfolio.description':
+      'Pogledajte kako smo pomogli našim klijentima da ostvare svoje digitalne ambicije i postignu izuzetne rezultate.',
+    'portfolio.filter.all': 'Sve',
+    'portfolio.filter.web-design': 'Web Design',
+    'portfolio.filter.ecommerce': 'E-commerce',
+    'portfolio.filter.branding': 'Branding',
+    'portfolio.filter.seo': 'SEO',
+    'portfolio.cta.title': 'Vaš projekat može biti sledeći',
+    'portfolio.cta.desc':
+      'Kontaktirajte nas danas i zajedno kreirajmo digitalno rešenje koje će transformisati vaš biznis.',
+    'portfolio.cta.primary': 'Započnite svoj projekat',
+    'portfolio.view': 'Pogledaj',
 
     // About
     'about.title': 'O nama',
@@ -234,9 +250,28 @@ const translations = {
     'about.values.title': 'Naše vrijednosti',
     'about.values.desc': 'Transparentnost, inovacija, rezultati i dugotrajne partnerske veze sa klijentima.',
 
+    'about.stats.title': 'Brojevi govore sami za sebe',
+    'about.stats.subtitle':
+      'Naši rezultati su dokaz posvećenosti kvalitetu i uspešnosti naših klijenata.',
+    'about.stats.clients': 'Zadovoljnih klijenata',
+    'about.stats.projects': 'Završenih projekata',
+    'about.stats.years': 'Godine iskustva',
+    'about.stats.success_rate': 'Stopa uspešnosti',
+    'about.team.title': 'Naš tim',
+    'about.team.subtitle': 'Upoznajte kreativne umove iza BDigital-a koji stvaraju digitalna rešenja.',
+    'about.cta.title': 'Spremni da radimo zajedno?',
+    'about.cta.desc':
+      'Pridružite se kompanijama koje su odabrale BDigital kao svog partnera za digitalni uspeh.',
+    'about.cta.primary': 'Kontaktirajte nas',
+    'about.cta.secondary': 'Pogledajte naš rad',
+
     // Testimonials
     'testimonials.title': 'Šta kažu naši klijenti',
     'testimonials.subtitle': 'Poverite nam svoj digitalni uspjeh',
+    'testimonials.stats.clients': 'Zadovoljnih klijenata',
+    'testimonials.stats.response': 'Vreme odgovora',
+    'testimonials.stats.years': 'Godine iskustva',
+    'testimonials.stats.projects': 'Završenih projekata',
 
     // Contact
     'contact.title': 'Kontaktirajte nas',
@@ -245,6 +280,29 @@ const translations = {
     'contact.email': 'Email',
     'contact.message': 'Poruka',
     'contact.send': 'Pošaljite poruku',
+    'contact.sending': 'Šalje se...',
+    'contact.badge': 'Kontakt',
+    'contact.heading.part1': 'Započnimo',
+    'contact.heading.emphasis': 'razgovor',
+    'contact.description':
+      'Spremi ste da transformišete svoj biznis? Kontaktirajte nas danas za besplatnu konsultaciju i saznajte kako možemo pomoći.',
+    'contact.form.title': 'Pošaljite nam poruku',
+    'contact.success.title': 'Poruka je uspešno poslata!',
+    'contact.success.desc': 'Kontaktiraćemo vas u najkraćem mogućem roku.',
+    'contact.company': 'Kompanija',
+    'contact.phone': 'Telefon',
+    'contact.stats.title.pre': 'Zašto klijenti biraju',
+    'contact.stats.title.emphasis': 'nas',
+    'contact.stats.response': 'Vreme odgovora',
+    'contact.stats.clients': 'Zadovoljni klijenti',
+    'contact.stats.support': 'Email podrška',
+    'contact.stats.years': 'Godina iskustva',
+    'contact.meeting.title': 'Zakazivanje sastanka',
+    'contact.meeting.desc':
+      'Preferirate lični razgovor? Možemo se sresti u našoj kancelariji u Podgorici ili bilo gde što vama odgovara.',
+    'contact.meeting.flexible': 'Fleksibilno vreme sastanka',
+    'contact.meeting.location': 'Lokacija po vašoj želji',
+    'contact.meeting.free': 'Besplatna konsultacija',
 
     // Footer
     'footer.description': 'Vaš partner za digitalni uspjeh u Crnoj Gori',
@@ -463,6 +521,22 @@ const translations = {
     'portfolio.seo': 'SEO Projects',
     'portfolio.social': 'Social Media',
     'portfolio.branding': 'Branding',
+    'portfolio.badge': 'Portfolio',
+    'portfolio.heading.part1': 'Our',
+    'portfolio.heading.emphasis': 'successful',
+    'portfolio.heading.part2': 'projects',
+    'portfolio.description':
+      'See how we helped our clients achieve their digital ambitions and outstanding results.',
+    'portfolio.filter.all': 'All',
+    'portfolio.filter.web-design': 'Web Design',
+    'portfolio.filter.ecommerce': 'E-commerce',
+    'portfolio.filter.branding': 'Branding',
+    'portfolio.filter.seo': 'SEO',
+    'portfolio.cta.title': 'Your project could be next',
+    'portfolio.cta.desc':
+      "Contact us today and together let's create a digital solution that will transform your business.",
+    'portfolio.cta.primary': 'Start your project',
+    'portfolio.view': 'View',
 
     // About
     'about.title': 'About Us',
@@ -477,9 +551,28 @@ const translations = {
     'about.values.title': 'Our Values',
     'about.values.desc': 'Transparency, innovation, results and long-term partnerships with clients.',
 
+    'about.stats.title': 'Numbers speak for themselves',
+    'about.stats.subtitle':
+      'Our results show our commitment to quality and success of our clients.',
+    'about.stats.clients': 'Happy clients',
+    'about.stats.projects': 'Completed projects',
+    'about.stats.years': 'Years of experience',
+    'about.stats.success_rate': 'Success rate',
+    'about.team.title': 'Our Team',
+    'about.team.subtitle': 'Meet the creative minds behind BDigital who craft digital solutions.',
+    'about.cta.title': 'Ready to work together?',
+    'about.cta.desc':
+      'Join the companies that chose BDigital as their partner for digital success.',
+    'about.cta.primary': 'Contact us',
+    'about.cta.secondary': 'View our work',
+
     // Testimonials
     'testimonials.title': 'What our clients say',
     'testimonials.subtitle': 'Trust us with your digital success',
+    'testimonials.stats.clients': 'Satisfied clients',
+    'testimonials.stats.response': 'Response time',
+    'testimonials.stats.years': 'Years of experience',
+    'testimonials.stats.projects': 'Completed projects',
 
     // Contact
     'contact.title': 'Contact us',
@@ -488,6 +581,29 @@ const translations = {
     'contact.email': 'Email',
     'contact.message': 'Message',
     'contact.send': 'Send message',
+    'contact.sending': 'Sending...',
+    'contact.badge': 'Contact',
+    'contact.heading.part1': "Let's start",
+    'contact.heading.emphasis': 'a conversation',
+    'contact.description':
+      'Ready to transform your business? Contact us today for a free consultation and learn how we can help.',
+    'contact.form.title': 'Send us a message',
+    'contact.success.title': 'Message sent successfully!',
+    'contact.success.desc': 'We will get back to you as soon as possible.',
+    'contact.company': 'Company',
+    'contact.phone': 'Phone',
+    'contact.stats.title.pre': 'Why clients choose',
+    'contact.stats.title.emphasis': 'us',
+    'contact.stats.response': 'Response time',
+    'contact.stats.clients': 'Happy clients',
+    'contact.stats.support': 'Email support',
+    'contact.stats.years': 'Years of experience',
+    'contact.meeting.title': 'Schedule a meeting',
+    'contact.meeting.desc':
+      'Prefer a face-to-face talk? We can meet at our office in Podgorica or wherever suits you.',
+    'contact.meeting.flexible': 'Flexible meeting time',
+    'contact.meeting.location': 'Location of your choice',
+    'contact.meeting.free': 'Free consultation',
 
     // Footer
     'footer.description': 'Your partner for digital success in Montenegro',

--- a/src/components/PortfolioSection.tsx
+++ b/src/components/PortfolioSection.tsx
@@ -20,11 +20,11 @@ export function PortfolioSection() {
   const [currentSlide, setCurrentSlide] = useState(0);
 
   const filters = [
-    { id: 'all', label: 'Sve', count: 12 },
-    { id: 'web-design', label: 'Web Design', count: 5 },
-    { id: 'ecommerce', label: 'E-commerce', count: 3 },
-    { id: 'branding', label: 'Branding', count: 2 },
-    { id: 'seo', label: 'SEO', count: 2 }
+    { id: 'all', label: _t('portfolio.filter.all'), count: 12 },
+    { id: 'web-design', label: _t('portfolio.filter.web-design'), count: 5 },
+    { id: 'ecommerce', label: _t('portfolio.filter.ecommerce'), count: 3 },
+    { id: 'branding', label: _t('portfolio.filter.branding'), count: 2 },
+    { id: 'seo', label: _t('portfolio.filter.seo'), count: 2 }
   ];
 
   const projects = [
@@ -145,13 +145,13 @@ export function PortfolioSection() {
         {/* Section Header */}
         <div className="text-center mb-12 lg:mb-16">
           <Badge className="bg-bdigital-cyan/10 text-bdigital-cyan border-bdigital-cyan/20 mb-4 px-4 py-2">
-            Portfolio
+            {_t('portfolio.badge')}
           </Badge>
           <h2 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-bdigital-navy mb-4 lg:mb-6">
-            Naši <span className="text-bdigital-cyan">uspešni</span> projekti
+            {_t('portfolio.heading.part1')} <span className="text-bdigital-cyan">{_t('portfolio.heading.emphasis')}</span> {_t('portfolio.heading.part2')}
           </h2>
           <p className="text-lg lg:text-xl text-neutral-gray max-w-3xl mx-auto leading-relaxed">
-            Pogledajte kako smo pomogli našim klijentima da ostvare svoje digitalne ambicije i postignu izuzetne rezultate.
+            {_t('portfolio.description')}
           </p>
         </div>
 
@@ -237,16 +237,16 @@ export function PortfolioSection() {
         <div className="text-center mt-12 lg:mt-16">
           <div className="bg-gradient-to-r from-bdigital-navy to-bdigital-dark-navy rounded-3xl p-8 lg:p-12 text-white">
             <h3 className="text-2xl lg:text-3xl font-bold mb-4">
-              Vaš projekat može biti sledeći
+              {_t('portfolio.cta.title')}
             </h3>
             <p className="text-gray-300 text-lg mb-6 lg:mb-8 max-w-2xl mx-auto">
-              Kontaktirajte nas danas i zajedno kreirajmo digitalno rešenje koje će transformisati vaš biznis.
+              {_t('portfolio.cta.desc')}
             </p>
             <Button
               onClick={() => navigateTo('service-inquiry')}
               className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light font-semibold px-8 py-3 transform hover:scale-105 transition-all duration-300 shadow-xl"
             >
-              Započnite svoj projekat
+              {_t('portfolio.cta.primary')}
             </Button>
           </div>
         </div>
@@ -258,6 +258,7 @@ export function PortfolioSection() {
 // Project Card Component
 function ProjectCard({ project }: { project: any }) {
   const [isHovered, setIsHovered] = useState(false);
+  const { t: _t } = useLanguage();
 
   return (
     <Card
@@ -291,7 +292,7 @@ function ProjectCard({ project }: { project: any }) {
                 className="bg-white/20 text-white hover:bg-white hover:text-bdigital-navy backdrop-blur-sm"
               >
                 <Eye className="h-4 w-4 mr-1" />
-                Pogledaj
+                {_t('portfolio.view')}
               </Button>
             </div>
           </div>

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -105,19 +105,19 @@ export function TestimonialsSection() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-8 max-w-4xl mx-auto">
             <div className="text-center">
               <div className="text-2xl font-bold text-digital-blue mb-2">100%</div>
-              <div className="text-sm text-neutral-gray">Zadovoljnih klijenata</div>
+              <div className="text-sm text-neutral-gray">{t('testimonials.stats.clients')}</div>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-digital-blue mb-2">24h</div>
-              <div className="text-sm text-neutral-gray">Vreme odgovora</div>
+              <div className="text-sm text-neutral-gray">{t('testimonials.stats.response')}</div>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-digital-blue mb-2">3+</div>
-              <div className="text-sm text-neutral-gray">Godine iskustva</div>
+              <div className="text-sm text-neutral-gray">{t('testimonials.stats.years')}</div>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-digital-blue mb-2">50+</div>
-              <div className="text-sm text-neutral-gray">Završenih projekata</div>
+              <div className="text-sm text-neutral-gray">{t('testimonials.stats.projects')}</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- localize stats and button text in About section
- localize portfolio section text and CTA
- localize testimonial stats
- localize entire contact section
- extend translation dictionary with new keys

## Testing
- `npm run lint` *(fails: Unexpected any and react-refresh errors)*
- `npm run build` *(fails: TS6133 in Router.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_688a0a1af68483238fad3790638d28ab