### PR TITLE
Add i18n for service inquiry and consultation forms

### DIFF
--- a/src/components/FreeConsultationPage.tsx
+++ b/src/components/FreeConsultationPage.tsx
@@ -85,15 +85,15 @@ export function FreeConsultationPage() {
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
     
-    if (!formData.fullName.trim()) newErrors.fullName = 'Ime je obavezno';
-    if (!formData.email.trim()) newErrors.email = 'Email je obavezan';
-    else if (!/\S+@\S+\.\S+/.test(formData.email)) newErrors.email = 'Email nije valjan';
-    if (!formData.company.trim()) newErrors.company = 'Kompanija je obavezna';
-    if (!formData.businessType) newErrors.businessType = 'Tip biznisa je obavezan';
-    if (!formData.currentChallenges.trim()) newErrors.currentChallenges = 'Ovo polje je obavezno';
-    if (!formData.goals.trim()) newErrors.goals = 'Ovo polje je obavezno';
-    if (formData.interestedServices.length === 0) newErrors.interestedServices = 'Odaberite najmanje jednu uslugu';
-    if (!formData.preferredContact) newErrors.preferredContact = 'Odaberite način kontakta';
+    if (!formData.fullName.trim()) newErrors.fullName = t('form.required_name');
+    if (!formData.email.trim()) newErrors.email = t('form.required_email');
+    else if (!/\S+@\S+\.\S+/.test(formData.email)) newErrors.email = t('form.invalid_email');
+    if (!formData.company.trim()) newErrors.company = t('form.required_company');
+    if (!formData.businessType) newErrors.businessType = t('form.required_business_type');
+    if (!formData.currentChallenges.trim()) newErrors.currentChallenges = t('form.required_field');
+    if (!formData.goals.trim()) newErrors.goals = t('form.required_field');
+    if (formData.interestedServices.length === 0) newErrors.interestedServices = t('form.required_services');
+    if (!formData.preferredContact) newErrors.preferredContact = t('form.required_contact');
     
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
@@ -178,7 +178,7 @@ export function FreeConsultationPage() {
                   }}
                   className="border-bdigital-cyan text-bdigital-cyan hover:bg-bdigital-cyan hover:text-bdigital-navy font-semibold px-8 py-3"
                 >
-                  Nova konsultacija
+                  {t('form.new_consultation')}
                 </Button>
               </div>
             </CardContent>
@@ -263,7 +263,7 @@ export function FreeConsultationPage() {
                   <Input
                     value={formData.fullName}
                     onChange={(e) => updateFormData('fullName', e.target.value)}
-                    placeholder="Vaše puno ime"
+                    placeholder={t('form.placeholder_full_name')}
                     className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan ${
                       errors.fullName ? 'border-red-500' : ''
                     }`}
@@ -284,7 +284,7 @@ export function FreeConsultationPage() {
                     type="email"
                     value={formData.email}
                     onChange={(e) => updateFormData('email', e.target.value)}
-                    placeholder="vasa@email.com"
+                    placeholder={t('form.placeholder_email')}
                     className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan ${
                       errors.email ? 'border-red-500' : ''
                     }`}
@@ -307,7 +307,7 @@ export function FreeConsultationPage() {
                   <Input
                     value={formData.phone}
                     onChange={(e) => updateFormData('phone', e.target.value)}
-                    placeholder="+382 67 123 456"
+                    placeholder={t('form.placeholder_phone')}
                     className="border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan"
                   />
                 </div>
@@ -319,7 +319,7 @@ export function FreeConsultationPage() {
                   <Input
                     value={formData.company}
                     onChange={(e) => updateFormData('company', e.target.value)}
-                    placeholder="Naziv vaše kompanije"
+                    placeholder={t('form.placeholder_company')}
                     className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan ${
                       errors.company ? 'border-red-500' : ''
                     }`}
@@ -342,7 +342,7 @@ export function FreeConsultationPage() {
                   <Input
                     value={formData.website}
                     onChange={(e) => updateFormData('website', e.target.value)}
-                    placeholder="https://www.vasasajt.com"
+                    placeholder={t('form.placeholder_website')}
                     className="border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan"
                   />
                 </div>
@@ -354,7 +354,7 @@ export function FreeConsultationPage() {
                     <SelectTrigger className={`border-gray-300 focus:border-bdigital-cyan ${
                       errors.businessType ? 'border-red-500' : ''
                     }`}>
-                      <SelectValue placeholder="Odaberite tip biznisa" />
+                      <SelectValue placeholder={t('form.placeholder_business_type')} />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="startup">Startup</SelectItem>
@@ -384,7 +384,7 @@ export function FreeConsultationPage() {
                 <Textarea
                   value={formData.currentChallenges}
                   onChange={(e) => updateFormData('currentChallenges', e.target.value)}
-                  placeholder="Opišite glavne izazove sa kojima se suočavate u digitalnom marketingu..."
+                  placeholder={t('form.placeholder_current_challenges')}
                   className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan min-h-[100px] resize-none ${
                     errors.currentChallenges ? 'border-red-500' : ''
                   }`}
@@ -405,7 +405,7 @@ export function FreeConsultationPage() {
                 <Textarea
                   value={formData.goals}
                   onChange={(e) => updateFormData('goals', e.target.value)}
-                  placeholder="Šta želite da postignete? (više klijenata, bolja online pozicija, povećanje prodaje...)"
+                  placeholder={t('form.placeholder_goals')}
                   className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan min-h-[100px] resize-none ${
                     errors.goals ? 'border-red-500' : ''
                   }`}
@@ -494,7 +494,7 @@ export function FreeConsultationPage() {
                   </Label>
                   <Select value={formData.preferredTime} onValueChange={(value) => updateFormData('preferredTime', value)}>
                     <SelectTrigger className="border-gray-300 focus:border-bdigital-cyan">
-                      <SelectValue placeholder="Kada vam odgovara?" />
+                      <SelectValue placeholder={t('form.placeholder_preferred_time')} />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="morning">Ujutru (09:00-12:00)</SelectItem>
@@ -515,7 +515,7 @@ export function FreeConsultationPage() {
                 <Textarea
                   value={formData.additionalInfo}
                   onChange={(e) => updateFormData('additionalInfo', e.target.value)}
-                  placeholder="Ima li još nešto što bi trebalo da znamo pre konsultacije?"
+                  placeholder={t('form.placeholder_additional_info_consult')}
                   className="border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan min-h-[80px] resize-none"
                 />
               </div>
@@ -542,12 +542,12 @@ export function FreeConsultationPage() {
                   {isSubmitting ? (
                     <>
                       <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-bdigital-navy mr-2"></div>
-                      Zakazuje se konsultacija...
+                      {t('form.scheduling')}
                     </>
                   ) : (
                     <>
                       <Calendar className="h-5 w-5 mr-2" />
-                      Zakaži besplatnu konsultaciju
+                      {t('form.submit_consultation')}
                     </>
                   )}
                 </Button>

--- a/src/components/LanguageContext.tsx
+++ b/src/components/LanguageContext.tsx
@@ -313,6 +313,48 @@ const translations = {
     // General
     'general.back_home': 'Nazad na početnu',
     'general.back': 'Nazad',
+    // Form
+    'form.required_name': 'Ime je obavezno',
+    'form.required_email': 'Email je obavezan',
+    'form.invalid_email': 'Email nije valjan',
+    'form.required_company': 'Kompanija je obavezna',
+    'form.required_project_types': 'Odaberite najmanje jedan tip projekta',
+    'form.required_field': 'Ovo polje je obavezno',
+    'form.required_timeline': 'Odaberite vremenski okvir',
+    'form.required_budget': 'Odaberite budžet',
+    'form.required_contact': 'Odaberite način kontakta',
+    'form.required_business_type': 'Tip biznisa je obavezan',
+    'form.required_services': 'Odaberite najmanje jednu uslugu',
+    'form.placeholder_full_name': 'Vaše puno ime',
+    'form.placeholder_email': 'vasa@email.com',
+    'form.placeholder_phone': '+382 67 123 456',
+    'form.placeholder_company': 'Naziv vaše kompanije',
+    'form.placeholder_website': 'https://www.vasasajt.com',
+    'form.placeholder_current_situation':
+      'Opišite šta trenutno imate (ili nemate) i zašto tražite naše usluge...',
+    'form.placeholder_project_goals':
+      'Šta želite da postignete ovim projektom? Povećanje prodaje, više klijenata, bolja online pozicija...',
+    'form.placeholder_target_audience':
+      'Ko su vaši idealni klijenti? (uzrast, lokacija, interesi...)',
+    'form.placeholder_timeline': 'Kada bi voleli da se projekat završi?',
+    'form.placeholder_budget': 'Koliki je vaš budžet za ovaj projekat?',
+    'form.placeholder_how_hear': 'Odaberite opciju',
+    'form.placeholder_current_challenges':
+      'Opišite glavne izazove sa kojima se suočavate u digitalnom marketingu...',
+    'form.placeholder_goals':
+      'Šta želite da postignete? (više klijenata, bolja online pozicija, povećanje prodaje...)',
+    'form.placeholder_preferred_time': 'Kada vam odgovara?',
+    'form.placeholder_additional_info':
+      'Ima li još nešto što bi trebalo da znamo o vašem projektu?',
+    'form.placeholder_additional_info_consult':
+      'Ima li još nešto što bi trebalo da znamo pre konsultacije?',
+    'form.next_step': 'Sledeći korak',
+    'form.submit_inquiry': 'Pošalji upit za ponudu',
+    'form.submitting': 'Šalje se...',
+    'form.submit_consultation': 'Zakaži besplatnu konsultaciju',
+    'form.scheduling': 'Zakazuje se konsultacija...',
+    'form.new_quote': 'Nova ponuda',
+    'form.new_consultation': 'Nova konsultacija',
     'packages.select': 'Odaberi paket',
   },
   en: {
@@ -614,6 +656,48 @@ const translations = {
     // General
     'general.back_home': 'Back to home',
     'general.back': 'Back',
+    // Form
+    'form.required_name': 'Name is required',
+    'form.required_email': 'Email is required',
+    'form.invalid_email': 'Invalid email',
+    'form.required_company': 'Company is required',
+    'form.required_project_types': 'Select at least one project type',
+    'form.required_field': 'This field is required',
+    'form.required_timeline': 'Select a timeline',
+    'form.required_budget': 'Select a budget',
+    'form.required_contact': 'Select a contact method',
+    'form.required_business_type': 'Business type is required',
+    'form.required_services': 'Select at least one service',
+    'form.placeholder_full_name': 'Your full name',
+    'form.placeholder_email': 'you@email.com',
+    'form.placeholder_phone': '+1 234 567 890',
+    'form.placeholder_company': 'Your company name',
+    'form.placeholder_website': 'https://www.yoursite.com',
+    'form.placeholder_current_situation':
+      'Describe your current situation and why you need our services...',
+    'form.placeholder_project_goals':
+      'What do you want to achieve with this project? More sales, more clients, better online presence...',
+    'form.placeholder_target_audience':
+      'Who are your ideal clients? (age, location, interests...)',
+    'form.placeholder_timeline': 'When would you like the project completed?',
+    'form.placeholder_budget': 'What is your budget for this project?',
+    'form.placeholder_how_hear': 'Select an option',
+    'form.placeholder_current_challenges':
+      'Describe the main challenges you face in digital marketing...',
+    'form.placeholder_goals':
+      'What do you want to achieve? (more clients, better ranking, increased sales...)',
+    'form.placeholder_preferred_time': 'What time works best for you?',
+    'form.placeholder_additional_info':
+      'Is there anything else we should know about your project?',
+    'form.placeholder_additional_info_consult':
+      'Is there anything else we should know before the consultation?',
+    'form.next_step': 'Next step',
+    'form.submit_inquiry': 'Submit inquiry',
+    'form.submitting': 'Sending...',
+    'form.submit_consultation': 'Schedule free consultation',
+    'form.scheduling': 'Scheduling consultation...',
+    'form.new_quote': 'New quote',
+    'form.new_consultation': 'New consultation',
     'packages.select': 'Choose package',
   },
 } as const;

--- a/src/components/ServiceInquiryForm.tsx
+++ b/src/components/ServiceInquiryForm.tsx
@@ -165,22 +165,22 @@ export function ServiceInquiryForm() {
     
     switch (step) {
       case 1:
-        if (!formData.fullName.trim()) newErrors.fullName = 'Ime je obavezno';
-        if (!formData.email.trim()) newErrors.email = 'Email je obavezan';
-        else if (!/\S+@\S+\.\S+/.test(formData.email)) newErrors.email = 'Email nije valjan';
-        if (!formData.company.trim()) newErrors.company = 'Kompanija je obavezna';
+        if (!formData.fullName.trim()) newErrors.fullName = t('form.required_name');
+        if (!formData.email.trim()) newErrors.email = t('form.required_email');
+        else if (!/\S+@\S+\.\S+/.test(formData.email)) newErrors.email = t('form.invalid_email');
+        if (!formData.company.trim()) newErrors.company = t('form.required_company');
         break;
       case 2:
-        if (formData.projectTypes.length === 0) newErrors.projectTypes = 'Odaberite najmanje jedan tip projekta';
-        if (!formData.currentSituation.trim()) newErrors.currentSituation = 'Ovo polje je obavezno';
-        if (!formData.projectGoals.trim()) newErrors.projectGoals = 'Ovo polje je obavezno';
+        if (formData.projectTypes.length === 0) newErrors.projectTypes = t('form.required_project_types');
+        if (!formData.currentSituation.trim()) newErrors.currentSituation = t('form.required_field');
+        if (!formData.projectGoals.trim()) newErrors.projectGoals = t('form.required_field');
         break;
       case 3:
-        if (!formData.timeline) newErrors.timeline = 'Odaberite vremenski okvir';
-        if (!formData.budget) newErrors.budget = 'Odaberite budžet';
+        if (!formData.timeline) newErrors.timeline = t('form.required_timeline');
+        if (!formData.budget) newErrors.budget = t('form.required_budget');
         break;
       case 4:
-        if (!formData.preferredContact) newErrors.preferredContact = 'Odaberite način kontakta';
+        if (!formData.preferredContact) newErrors.preferredContact = t('form.required_contact');
         break;
     }
     
@@ -276,7 +276,7 @@ export function ServiceInquiryForm() {
                   }}
                   className="border-bdigital-cyan text-bdigital-cyan hover:bg-bdigital-cyan hover:text-bdigital-navy font-semibold px-8 py-3"
                 >
-                  Nova ponuda
+                  {t('form.new_quote')}
                 </Button>
               </div>
             </CardContent>
@@ -429,7 +429,7 @@ export function ServiceInquiryForm() {
                     <Input
                       value={formData.fullName}
                       onChange={(e) => updateFormData('fullName', e.target.value)}
-                      placeholder="Vaše puno ime"
+                      placeholder={t('form.placeholder_full_name')}
                       className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan ${
                         errors.fullName ? 'border-red-500' : ''
                       }`}
@@ -450,7 +450,7 @@ export function ServiceInquiryForm() {
                       type="email"
                       value={formData.email}
                       onChange={(e) => updateFormData('email', e.target.value)}
-                      placeholder="vasa@email.com"
+                      placeholder={t('form.placeholder_email')}
                       className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan ${
                         errors.email ? 'border-red-500' : ''
                       }`}
@@ -473,7 +473,7 @@ export function ServiceInquiryForm() {
                     <Input
                       value={formData.phone}
                       onChange={(e) => updateFormData('phone', e.target.value)}
-                      placeholder="+382 67 123 456"
+                      placeholder={t('form.placeholder_phone')}
                       className="border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan"
                     />
                   </div>
@@ -485,7 +485,7 @@ export function ServiceInquiryForm() {
                     <Input
                       value={formData.company}
                       onChange={(e) => updateFormData('company', e.target.value)}
-                      placeholder="Naziv vaše kompanije"
+                      placeholder={t('form.placeholder_company')}
                       className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan ${
                         errors.company ? 'border-red-500' : ''
                       }`}
@@ -507,7 +507,7 @@ export function ServiceInquiryForm() {
                   <Input
                     value={formData.website}
                     onChange={(e) => updateFormData('website', e.target.value)}
-                    placeholder="https://www.vasasajt.com"
+                    placeholder={t('form.placeholder_website')}
                     className="border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan"
                   />
                 </div>
@@ -560,7 +560,7 @@ export function ServiceInquiryForm() {
                   <Textarea
                     value={formData.currentSituation}
                     onChange={(e) => updateFormData('currentSituation', e.target.value)}
-                    placeholder="Opišite šta trenutno imate (ili nemate) i zašto tražite naše usluge..."
+                    placeholder={t('form.placeholder_current_situation')}
                     className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan min-h-[100px] resize-none ${
                       errors.currentSituation ? 'border-red-500' : ''
                     }`}
@@ -580,7 +580,7 @@ export function ServiceInquiryForm() {
                   <Textarea
                     value={formData.projectGoals}
                     onChange={(e) => updateFormData('projectGoals', e.target.value)}
-                    placeholder="Šta želite da postignete ovim projektom? Povećanje prodaje, više klijenata, bolja online pozicija..."
+                    placeholder={t('form.placeholder_project_goals')}
                     className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan min-h-[100px] resize-none ${
                       errors.projectGoals ? 'border-red-500' : ''
                     }`}
@@ -600,7 +600,7 @@ export function ServiceInquiryForm() {
                   <Input
                     value={formData.targetAudience}
                     onChange={(e) => updateFormData('targetAudience', e.target.value)}
-                    placeholder="Ko su vaši idealni klijenti? (uzrast, lokacija, interesi...)"
+                    placeholder={t('form.placeholder_target_audience')}
                     className="border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan"
                   />
                 </div>
@@ -619,7 +619,7 @@ export function ServiceInquiryForm() {
                     <SelectTrigger className={`border-gray-300 focus:border-bdigital-cyan ${
                       errors.timeline ? 'border-red-500' : ''
                     }`}>
-                      <SelectValue placeholder="Kada bi voleli da se projekat završi?" />
+                      <SelectValue placeholder={t('form.placeholder_timeline')} />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="asap">Što pre moguće</SelectItem>
@@ -646,7 +646,7 @@ export function ServiceInquiryForm() {
                     <SelectTrigger className={`border-gray-300 focus:border-bdigital-cyan ${
                       errors.budget ? 'border-red-500' : ''
                     }`}>
-                      <SelectValue placeholder="Koliki je vaš budžet za ovaj projekat?" />
+                      <SelectValue placeholder={t('form.placeholder_budget')} />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="under-1000">Manje od 1.000 €</SelectItem>
@@ -738,7 +738,7 @@ export function ServiceInquiryForm() {
                   </Label>
                   <Select value={formData.howDidYouHear} onValueChange={(value) => updateFormData('howDidYouHear', value)}>
                     <SelectTrigger className="border-gray-300 focus:border-bdigital-cyan">
-                      <SelectValue placeholder="Odaberite opciju" />
+                      <SelectValue placeholder={t('form.placeholder_how_hear')} />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="google">Google pretraga</SelectItem>
@@ -759,7 +759,7 @@ export function ServiceInquiryForm() {
                   <Textarea
                     value={formData.additionalInfo}
                     onChange={(e) => updateFormData('additionalInfo', e.target.value)}
-                    placeholder="Ima li još nešto što bi trebalo da znamo o vašem projektu?"
+                    placeholder={t('form.placeholder_additional_info')}
                     className="border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan min-h-[100px] resize-none"
                   />
                 </div>
@@ -794,7 +794,7 @@ export function ServiceInquiryForm() {
                   onClick={nextStep}
                   className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light font-semibold px-8 py-3"
                 >
-                  Sledeći korak
+                  {t('form.next_step')}
                   <ChevronRight className="h-4 w-4 ml-2" />
                 </Button>
               ) : (
@@ -806,12 +806,12 @@ export function ServiceInquiryForm() {
                   {isSubmitting ? (
                     <>
                       <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-bdigital-navy mr-2"></div>
-                      Šalje se...
+                      {t('form.submitting')}
                     </>
                   ) : (
                     <>
                       <Send className="h-5 w-5 mr-2" />
-                      Pošalji upit za ponudu
+                      {t('form.submit_inquiry')}
                     </>
                   )}
                 </Button>


### PR DESCRIPTION
## Summary
- internationalize ServiceInquiryForm and FreeConsultationPage placeholders, errors and buttons
- add translation keys for form fields and messages in LanguageContext

## Testing
- `npm run lint` *(fails: unexpected any / react-refresh only-export-components)*

------
https://chatgpt.com/codex/tasks/task_e_688a0ce9b8f083239cf7b8555f21a04c