### PR TITLE
Define Project type and fix imports

### DIFF
--- a/src/components/PortfolioSection.tsx
+++ b/src/components/PortfolioSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import type { Project } from '../types';
 import { Button } from './ui/button';
 import { Card, CardContent } from './ui/card';
 import { Badge } from './ui/badge';
@@ -27,7 +28,7 @@ export function PortfolioSection() {
     { id: 'seo', label: _t('portfolio.filter.seo'), count: 2 }
   ];
 
-  const projects = [
+  const projects: Project[] = [
     {
       id: 1,
       title: 'Montenegrin Properties',
@@ -256,7 +257,7 @@ export function PortfolioSection() {
 }
 
 // Project Card Component
-function ProjectCard({ project }: { project: any }) {
+function ProjectCard({ project }: { project: Project }) {
   const [isHovered, setIsHovered] = useState(false);
   const { t: _t } = useLanguage();
 

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,5 +1,6 @@
 
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect } from 'react';
+import type { ReactNode } from 'react';
 
 export type PageType = 
   | 'home' 

--- a/src/components/figma/ImageWithFallback.tsx
+++ b/src/components/figma/ImageWithFallback.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
+import type { ImgHTMLAttributes } from 'react'
 
 const ERROR_IMG_SRC =
   'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODgiIGhlaWdodD0iODgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgc3Ryb2tlPSIjMDAwIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBvcGFjaXR5PSIuMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIzLjciPjxyZWN0IHg9IjE2IiB5PSIxNiIgd2lkdGg9IjU2IiBoZWlnaHQ9IjU2IiByeD0iNiIvPjxwYXRoIGQ9Im0xNiA1OCAxNi0xOCAzMiAzMiIvPjxjaXJjbGUgY3g9IjUzIiBjeT0iMzUiIHI9IjciLz48L3N2Zz4KCg=='
 
-export function ImageWithFallback(props: React.ImgHTMLAttributes<HTMLImageElement>) {
+export function ImageWithFallback(props: ImgHTMLAttributes<HTMLImageElement>) {
   const [didError, setDidError] = useState(false)
 
   const handleError = () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,15 @@
+export interface Project {
+  id: number
+  title: string
+  category: string
+  categoryLabel: string
+  description: string
+  image: string
+  technologies: string[]
+  results: string[]
+  year: string
+  client: string
+  duration: string
+  link: string
+}
+


### PR DESCRIPTION
## Summary
- add `Project` interface for portfolio items
- use new `Project` type in `PortfolioSection`
- clean up React imports for ESM compliance
- adjust `ImageWithFallback` to use type-only import
- build project to verify compilation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a130cf9588323b7920ba7b0f1a6ef