### PR TITLE
Add inquiry translations and dynamic headings

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -256,7 +256,7 @@ export function Navigation() {
               onClick={() => navigateTo("free-consultation")}
               className="bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light font-semibold px-6 py-2 text-sm shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105"
             >
-              Besplatna konsultacija
+              {t('web.cta.primary')}
             </Button>
           </div>
 
@@ -389,7 +389,7 @@ export function Navigation() {
                       }}
                       className="w-full bg-bdigital-cyan text-bdigital-navy hover:bg-bdigital-cyan-light font-semibold py-3 text-sm shadow-lg transition-all duration-300"
                     >
-                      Besplatna konsultacija
+                      {t('web.cta.primary')}
                     </Button>
                   </div>
                 </div>

--- a/src/components/ServiceInquiryForm.tsx
+++ b/src/components/ServiceInquiryForm.tsx
@@ -145,7 +145,7 @@ export function ServiceInquiryForm() {
     }
   }, []);
 
-  const updateFormData = (field: keyof InquiryFormData, value: any) => {
+  const updateFormData = (field: keyof InquiryFormData, value: unknown) => {
     setFormData(prev => ({
       ...prev,
       [field]: value
@@ -302,10 +302,10 @@ export function ServiceInquiryForm() {
           
           <div className="text-center mb-8">
             <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-bdigital-navy mb-4">
-              Upit za <span className="text-bdigital-cyan">ponudu</span>
+              {t('inquiry.title')}
             </h1>
             <p className="text-lg text-neutral-gray max-w-2xl mx-auto">
-              Popunite formu ispod da bismo pripremili personalizovanu ponudu za vaš projekat.
+              {t('inquiry.subtitle')}
             </p>
           </div>
 
@@ -371,10 +371,10 @@ export function ServiceInquiryForm() {
             <span className="text-sm text-neutral-gray">{Math.round(progressPercentage)}% završeno</span>
           </div>
           <Progress value={progressPercentage} className="h-2 mb-6" />
-          
+
           {/* Step Indicators */}
           <div className="flex items-center justify-between">
-            {steps.map((step, _index) => {
+            {steps.map((step) => {
               const IconComponent = step.icon;
               const isActive = currentStep === step.id;
               const isCompleted = currentStep > step.id;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -423,5 +423,8 @@
   "branding.package.enterprise.feature2": "Packaging design",
   "branding.package.enterprise.feature3": "Unlimited revisions",
   "branding.package.enterprise.feature4": "Complete identity",
-  "branding.package.enterprise.feature5": "12 months support"
+  "branding.package.enterprise.feature5": "12 months support",
+  "inquiry.title": "Request a quote",
+  "inquiry.subtitle": "Fill out the form below so we can prepare a personalized quote for your project."
 }
+

--- a/src/locales/me.json
+++ b/src/locales/me.json
@@ -424,5 +424,8 @@
   "branding.package.enterprise.feature2": "Packaging dizajn",
   "branding.package.enterprise.feature3": "Neograničene revizije",
   "branding.package.enterprise.feature4": "Kompletan identitet",
-  "branding.package.enterprise.feature5": "12 meseci podrška"
+  "branding.package.enterprise.feature5": "12 meseci podrška",
+  "inquiry.title": "Upit za ponudu",
+  "inquiry.subtitle": "Popunite formu ispod da bismo pripremili personalizovanu ponudu za vaš projekat."
 }
+


### PR DESCRIPTION
## Summary
- translate service inquiry headings
- hook navigation CTAs to translation keys
- add translation strings for inquiry form in EN and ME locales

## Testing
- `npm run lint` *(fails: Unexpected any and export errors in unrelated files)*
- `npx eslint src/components/ServiceInquiryForm.tsx src/components/Navigation.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688b46f0865883239927514b0bb3613a