### PR TITLE
Add real-time validation tooltips

### DIFF
--- a/src/components/ServiceInquiryForm.tsx
+++ b/src/components/ServiceInquiryForm.tsx
@@ -114,19 +114,63 @@ export function ServiceInquiryForm() {
     }
   }, []);
 
-  const updateFormData = (field: keyof InquiryFormData, value: unknown) => {
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+
+  const validateField = (
+    field: keyof InquiryFormData,
+    value: unknown
+  ): string => {
+    switch (field) {
+      case 'fullName':
+        return !String(value).trim() ? t('form.required_name') : '';
+      case 'email':
+        if (!String(value).trim()) return t('form.required_email');
+        return /\S+@\S+\.\S+/.test(String(value))
+          ? ''
+          : t('form.invalid_email');
+      case 'company':
+        return !String(value).trim() ? t('form.required_company') : '';
+      case 'projectTypes':
+        return (value as string[]).length === 0
+          ? t('form.required_project_types')
+          : '';
+      case 'currentSituation':
+      case 'projectGoals':
+        return !String(value).trim() ? t('form.required_field') : '';
+      case 'timeline':
+        return !value ? t('form.required_timeline') : '';
+      case 'budget':
+        return !value ? t('form.required_budget') : '';
+      case 'preferredContact':
+        return !value ? t('form.required_contact') : '';
+      default:
+        return '';
+    }
+  };
+
+  const updateFormData = (
+    field: keyof InquiryFormData,
+    value: unknown
+  ) => {
     setFormData(prev => ({
       ...prev,
       [field]: value
     }));
-    
-    // Clear error when user starts typing
-    if (errors[field]) {
-      setErrors(prev => ({
-        ...prev,
-        [field]: ''
-      }));
-    }
+
+    setTouched(prev => ({ ...prev, [field]: true }));
+
+    setErrors(prev => ({
+      ...prev,
+      [field]: validateField(field, value)
+    }));
+  };
+
+  const handleBlur = (field: keyof InquiryFormData) => {
+    setTouched(prev => ({ ...prev, [field]: true }));
+    setErrors(prev => ({
+      ...prev,
+      [field]: validateField(field, formData[field])
+    }));
   };
 
   const validateStep = (step: number): boolean => {
@@ -158,21 +202,19 @@ export function ServiceInquiryForm() {
   };
 
   const handleProjectTypeChange = (projectType: string, checked: boolean) => {
-    setFormData(prev => ({
-      ...prev,
-      projectTypes: checked 
-        ? [...prev.projectTypes, projectType]
-        : prev.projectTypes.filter(type => type !== projectType)
-    }));
+    const newValue = checked
+      ? [...formData.projectTypes, projectType]
+      : formData.projectTypes.filter(type => type !== projectType);
+
+    updateFormData('projectTypes', newValue);
   };
 
   const handleAdditionalServicesChange = (service: string, checked: boolean) => {
-    setFormData(prev => ({
-      ...prev,
-      additionalServices: checked 
-        ? [...prev.additionalServices, service]
-        : prev.additionalServices.filter(s => s !== service)
-    }));
+    const newValue = checked
+      ? [...formData.additionalServices, service]
+      : formData.additionalServices.filter(s => s !== service);
+
+    updateFormData('additionalServices', newValue);
   };
 
   const handleSubmit = async () => {
@@ -395,7 +437,13 @@ export function ServiceInquiryForm() {
                   exit={{ x: -100, opacity: 0 }}
                   transition={{ duration: 0.3 }}
                 >
-                  <Step1 formData={formData} errors={errors} updateFormData={updateFormData} />
+                  <Step1
+                    formData={formData}
+                    errors={errors}
+                    touched={touched}
+                    updateFormData={updateFormData}
+                    handleBlur={handleBlur}
+                  />
                 </motion.div>
               )}
               {currentStep === 2 && (
@@ -409,8 +457,10 @@ export function ServiceInquiryForm() {
                   <Step2
                     formData={formData}
                     errors={errors}
+                    touched={touched}
                     updateFormData={updateFormData}
                     handleProjectTypeChange={handleProjectTypeChange}
+                    handleBlur={handleBlur}
                   />
                 </motion.div>
               )}
@@ -425,8 +475,10 @@ export function ServiceInquiryForm() {
                   <Step3
                     formData={formData}
                     errors={errors}
+                    touched={touched}
                     updateFormData={updateFormData}
                     handleAdditionalServicesChange={handleAdditionalServicesChange}
+                    handleBlur={handleBlur}
                   />
                 </motion.div>
               )}
@@ -438,7 +490,13 @@ export function ServiceInquiryForm() {
                   exit={{ x: -100, opacity: 0 }}
                   transition={{ duration: 0.3 }}
                 >
-                  <Step4 formData={formData} errors={errors} updateFormData={updateFormData} />
+                  <Step4
+                    formData={formData}
+                    errors={errors}
+                    touched={touched}
+                    updateFormData={updateFormData}
+                    handleBlur={handleBlur}
+                  />
                 </motion.div>
               )}
             </AnimatePresence>

--- a/src/components/serviceInquirySteps/Step1.tsx
+++ b/src/components/serviceInquirySteps/Step1.tsx
@@ -1,16 +1,25 @@
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
-import { AlertCircle, Building, Globe, Mail, Phone, User } from 'lucide-react';
+import { Building, Globe, Mail, Phone, User } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { useLanguage } from '../LanguageContext';
 import type { InquiryFormData } from '../ServiceInquiryForm';
 
 interface Step1Props {
   formData: InquiryFormData;
   errors: Record<string, string>;
+  touched: Record<string, boolean>;
   updateFormData: (field: keyof InquiryFormData, value: unknown) => void;
+  handleBlur: (field: keyof InquiryFormData) => void;
 }
 
-export function Step1({ formData, errors, updateFormData }: Step1Props) {
+export function Step1({
+  formData,
+  errors,
+  touched,
+  updateFormData,
+  handleBlur
+}: Step1Props) {
   const { t } = useLanguage();
 
   return (
@@ -21,37 +30,37 @@ export function Step1({ formData, errors, updateFormData }: Step1Props) {
             <User className="h-4 w-4" />
             {t('form.full_name')}
           </Label>
-          <Input
-            value={formData.fullName}
-            onChange={e => updateFormData('fullName', e.target.value)}
-            placeholder={t('form.placeholder_full_name')}
-            className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan ${errors.fullName ? 'border-red-500' : ''}`}
-          />
-          {errors.fullName && (
-            <div className="flex items-center mt-1 text-red-600 text-sm">
-              <AlertCircle className="h-4 w-4 mr-1" />
-              {errors.fullName}
-            </div>
-          )}
+          <Tooltip open={!!errors.fullName && touched.fullName}>
+            <TooltipTrigger asChild>
+              <Input
+                value={formData.fullName}
+                onChange={e => updateFormData('fullName', e.target.value)}
+                onBlur={() => handleBlur('fullName')}
+                placeholder={t('form.placeholder_full_name')}
+                className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan ${errors.fullName && touched.fullName ? 'border-red-500' : ''}`}
+              />
+            </TooltipTrigger>
+            <TooltipContent side="right">{errors.fullName}</TooltipContent>
+          </Tooltip>
         </div>
         <div>
           <Label className="flex items-center gap-2 mb-2 text-bdigital-navy">
             <Mail className="h-4 w-4" />
             {t('form.email')}
           </Label>
-          <Input
-            type="email"
-            value={formData.email}
-            onChange={e => updateFormData('email', e.target.value)}
-            placeholder={t('form.placeholder_email')}
-            className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan ${errors.email ? 'border-red-500' : ''}`}
-          />
-          {errors.email && (
-            <div className="flex items-center mt-1 text-red-600 text-sm">
-              <AlertCircle className="h-4 w-4 mr-1" />
-              {errors.email}
-            </div>
-          )}
+          <Tooltip open={!!errors.email && touched.email}>
+            <TooltipTrigger asChild>
+              <Input
+                type="email"
+                value={formData.email}
+                onChange={e => updateFormData('email', e.target.value)}
+                onBlur={() => handleBlur('email')}
+                placeholder={t('form.placeholder_email')}
+                className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan ${errors.email && touched.email ? 'border-red-500' : ''}`}
+              />
+            </TooltipTrigger>
+            <TooltipContent side="right">{errors.email}</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 
@@ -73,18 +82,18 @@ export function Step1({ formData, errors, updateFormData }: Step1Props) {
             <Building className="h-4 w-4" />
             {t('form.company')}
           </Label>
-          <Input
-            value={formData.company}
-            onChange={e => updateFormData('company', e.target.value)}
-            placeholder={t('form.placeholder_company')}
-            className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan ${errors.company ? 'border-red-500' : ''}`}
-          />
-          {errors.company && (
-            <div className="flex items-center mt-1 text-red-600 text-sm">
-              <AlertCircle className="h-4 w-4 mr-1" />
-              {errors.company}
-            </div>
-          )}
+          <Tooltip open={!!errors.company && touched.company}>
+            <TooltipTrigger asChild>
+              <Input
+                value={formData.company}
+                onChange={e => updateFormData('company', e.target.value)}
+                onBlur={() => handleBlur('company')}
+                placeholder={t('form.placeholder_company')}
+                className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan ${errors.company && touched.company ? 'border-red-500' : ''}`}
+              />
+            </TooltipTrigger>
+            <TooltipContent side="right">{errors.company}</TooltipContent>
+          </Tooltip>
         </div>
       </div>
 

--- a/src/components/serviceInquirySteps/Step2.tsx
+++ b/src/components/serviceInquirySteps/Step2.tsx
@@ -2,22 +2,26 @@ import { Checkbox } from '../ui/checkbox';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Textarea } from '../ui/textarea';
-import { AlertCircle } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { useLanguage } from '../LanguageContext';
 import type { InquiryFormData } from '../ServiceInquiryForm';
 
 interface Step2Props {
   formData: InquiryFormData;
   errors: Record<string, string>;
+  touched: Record<string, boolean>;
   updateFormData: (field: keyof InquiryFormData, value: unknown) => void;
   handleProjectTypeChange: (projectType: string, checked: boolean) => void;
+  handleBlur: (field: keyof InquiryFormData) => void;
 }
 
 export function Step2({
   formData,
   errors,
+  touched,
   updateFormData,
-  handleProjectTypeChange
+  handleProjectTypeChange,
+  handleBlur
 }: Step2Props) {
   const { t } = useLanguage();
 
@@ -27,74 +31,73 @@ export function Step2({
         <Label className="mb-3 block text-bdigital-navy">
           {t('form.project_types_label')}
         </Label>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {[
-            { value: 'new-website', label: t('form.project_type.new_website') },
-            { value: 'redesign', label: t('form.project_type.redesign') },
-            { value: 'ecommerce', label: t('form.project_type.ecommerce') },
-            { value: 'mobile-app', label: t('form.project_type.mobile_app') },
-            { value: 'seo-optimization', label: t('form.project_type.seo_optimization') },
-            { value: 'social-media', label: t('form.project_type.social_media') },
-            { value: 'branding', label: t('form.project_type.branding') },
-            { value: 'marketing-strategy', label: t('form.project_type.marketing_strategy') },
-            { value: 'other', label: t('form.project_type.other') }
-          ].map(projectType => (
-            <div key={projectType.value} className="flex items-center space-x-2">
-              <Checkbox
-                checked={formData.projectTypes.includes(projectType.value)}
-                onCheckedChange={checked =>
-                  handleProjectTypeChange(projectType.value, checked as boolean)
-                }
-                className="border-gray-300"
-              />
-              <Label className="text-sm font-normal text-neutral-gray">
-                {projectType.label}
-              </Label>
+        <Tooltip open={!!errors.projectTypes && touched.projectTypes}>
+          <TooltipTrigger asChild>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {[
+                { value: 'new-website', label: t('form.project_type.new_website') },
+                { value: 'redesign', label: t('form.project_type.redesign') },
+                { value: 'ecommerce', label: t('form.project_type.ecommerce') },
+                { value: 'mobile-app', label: t('form.project_type.mobile_app') },
+                { value: 'seo-optimization', label: t('form.project_type.seo_optimization') },
+                { value: 'social-media', label: t('form.project_type.social_media') },
+                { value: 'branding', label: t('form.project_type.branding') },
+                { value: 'marketing-strategy', label: t('form.project_type.marketing_strategy') },
+                { value: 'other', label: t('form.project_type.other') }
+              ].map(projectType => (
+                <div key={projectType.value} className="flex items-center space-x-2">
+                  <Checkbox
+                    checked={formData.projectTypes.includes(projectType.value)}
+                    onCheckedChange={checked =>
+                      handleProjectTypeChange(projectType.value, checked as boolean)
+                    }
+                    className="border-gray-300"
+                  />
+                  <Label className="text-sm font-normal text-neutral-gray">
+                    {projectType.label}
+                  </Label>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-        {errors.projectTypes && (
-          <div className="flex items-center mt-2 text-red-600 text-sm">
-            <AlertCircle className="h-4 w-4 mr-1" />
-            {errors.projectTypes}
-          </div>
-        )}
+          </TooltipTrigger>
+          <TooltipContent side="right">{errors.projectTypes}</TooltipContent>
+        </Tooltip>
       </div>
 
       <div>
         <Label className="mb-2 block text-bdigital-navy">
           {t('form.current_situation')}
         </Label>
-        <Textarea
-          value={formData.currentSituation}
-          onChange={e => updateFormData('currentSituation', e.target.value)}
-          placeholder={t('form.placeholder_current_situation')}
-          className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan min-h-[100px] resize-none ${errors.currentSituation ? 'border-red-500' : ''}`}
-        />
-        {errors.currentSituation && (
-          <div className="flex items-center mt-1 text-red-600 text-sm">
-            <AlertCircle className="h-4 w-4 mr-1" />
-            {errors.currentSituation}
-          </div>
-        )}
+        <Tooltip open={!!errors.currentSituation && touched.currentSituation}>
+          <TooltipTrigger asChild>
+            <Textarea
+              value={formData.currentSituation}
+              onChange={e => updateFormData('currentSituation', e.target.value)}
+              onBlur={() => handleBlur('currentSituation')}
+              placeholder={t('form.placeholder_current_situation')}
+              className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan min-h-[100px] resize-none ${errors.currentSituation && touched.currentSituation ? 'border-red-500' : ''}`}
+            />
+          </TooltipTrigger>
+          <TooltipContent side="right">{errors.currentSituation}</TooltipContent>
+        </Tooltip>
       </div>
 
       <div>
         <Label className="mb-2 block text-bdigital-navy">
           {t('form.project_goals')}
         </Label>
-        <Textarea
-          value={formData.projectGoals}
-          onChange={e => updateFormData('projectGoals', e.target.value)}
-          placeholder={t('form.placeholder_project_goals')}
-          className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan min-h-[100px] resize-none ${errors.projectGoals ? 'border-red-500' : ''}`}
-        />
-        {errors.projectGoals && (
-          <div className="flex items-center mt-1 text-red-600 text-sm">
-            <AlertCircle className="h-4 w-4 mr-1" />
-            {errors.projectGoals}
-          </div>
-        )}
+        <Tooltip open={!!errors.projectGoals && touched.projectGoals}>
+          <TooltipTrigger asChild>
+            <Textarea
+              value={formData.projectGoals}
+              onChange={e => updateFormData('projectGoals', e.target.value)}
+              onBlur={() => handleBlur('projectGoals')}
+              placeholder={t('form.placeholder_project_goals')}
+              className={`border-gray-300 focus:border-bdigital-cyan focus:ring-bdigital-cyan min-h-[100px] resize-none ${errors.projectGoals && touched.projectGoals ? 'border-red-500' : ''}`}
+            />
+          </TooltipTrigger>
+          <TooltipContent side="right">{errors.projectGoals}</TooltipContent>
+        </Tooltip>
       </div>
 
       <div>

--- a/src/components/serviceInquirySteps/Step3.tsx
+++ b/src/components/serviceInquirySteps/Step3.tsx
@@ -1,22 +1,27 @@
 import { Checkbox } from '../ui/checkbox';
 import { Label } from '../ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
-import { AlertCircle, Calendar, DollarSign } from 'lucide-react';
+import { Calendar, DollarSign } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { useLanguage } from '../LanguageContext';
 import type { InquiryFormData } from '../ServiceInquiryForm';
 
 interface Step3Props {
   formData: InquiryFormData;
   errors: Record<string, string>;
+  touched: Record<string, boolean>;
   updateFormData: (field: keyof InquiryFormData, value: unknown) => void;
   handleAdditionalServicesChange: (service: string, checked: boolean) => void;
+  handleBlur: (field: keyof InquiryFormData) => void;
 }
 
 export function Step3({
   formData,
   errors,
+  touched,
   updateFormData,
-  handleAdditionalServicesChange
+  handleAdditionalServicesChange,
+  handleBlur
 }: Step3Props) {
   const { t } = useLanguage();
 
@@ -27,24 +32,29 @@ export function Step3({
           <Calendar className="h-4 w-4" />
           {t('form.timeline')}
         </Label>
-        <Select value={formData.timeline} onValueChange={value => updateFormData('timeline', value)}>
-          <SelectTrigger className={`border-gray-300 focus:border-bdigital-cyan ${errors.timeline ? 'border-red-500' : ''}`}>
-            <SelectValue placeholder={t('form.placeholder_timeline')} />
-          </SelectTrigger>
-          <SelectContent forceMount>
-            <SelectItem value="asap">{t('form.timeline_option.asap')}</SelectItem>
-            <SelectItem value="1-month">{t('form.timeline_option.one_month')}</SelectItem>
-            <SelectItem value="2-3-months">{t('form.timeline_option.two_three_months')}</SelectItem>
-            <SelectItem value="3-6-months">{t('form.timeline_option.three_six_months')}</SelectItem>
-            <SelectItem value="flexible">{t('form.timeline_option.flexible')}</SelectItem>
-          </SelectContent>
-        </Select>
-        {errors.timeline && (
-          <div className="flex items-center mt-1 text-red-600 text-sm">
-            <AlertCircle className="h-4 w-4 mr-1" />
-            {errors.timeline}
-          </div>
-        )}
+        <Tooltip open={!!errors.timeline && touched.timeline}>
+          <TooltipTrigger asChild>
+            <Select
+              value={formData.timeline}
+              onValueChange={value => updateFormData('timeline', value)}
+            >
+              <SelectTrigger
+                onBlur={() => handleBlur('timeline')}
+                className={`border-gray-300 focus:border-bdigital-cyan ${errors.timeline && touched.timeline ? 'border-red-500' : ''}`}
+              >
+                <SelectValue placeholder={t('form.placeholder_timeline')} />
+              </SelectTrigger>
+              <SelectContent forceMount>
+                <SelectItem value="asap">{t('form.timeline_option.asap')}</SelectItem>
+                <SelectItem value="1-month">{t('form.timeline_option.one_month')}</SelectItem>
+                <SelectItem value="2-3-months">{t('form.timeline_option.two_three_months')}</SelectItem>
+                <SelectItem value="3-6-months">{t('form.timeline_option.three_six_months')}</SelectItem>
+                <SelectItem value="flexible">{t('form.timeline_option.flexible')}</SelectItem>
+              </SelectContent>
+            </Select>
+          </TooltipTrigger>
+          <TooltipContent side="right">{errors.timeline}</TooltipContent>
+        </Tooltip>
       </div>
 
       <div>
@@ -52,25 +62,30 @@ export function Step3({
           <DollarSign className="h-4 w-4" />
           {t('form.budget')}
         </Label>
-        <Select value={formData.budget} onValueChange={value => updateFormData('budget', value)}>
-          <SelectTrigger className={`border-gray-300 focus:border-bdigital-cyan ${errors.budget ? 'border-red-500' : ''}`}>
-            <SelectValue placeholder={t('form.placeholder_budget')} />
-          </SelectTrigger>
-          <SelectContent forceMount>
-            <SelectItem value="under-1000">{t('form.budget_option.under_1000')}</SelectItem>
-            <SelectItem value="1000-2500">{t('form.budget_option.1000_2500')}</SelectItem>
-            <SelectItem value="2500-5000">{t('form.budget_option.2500_5000')}</SelectItem>
-            <SelectItem value="5000-10000">{t('form.budget_option.5000_10000')}</SelectItem>
-            <SelectItem value="over-10000">{t('form.budget_option.over_10000')}</SelectItem>
-            <SelectItem value="discuss">{t('form.budget_option.discuss')}</SelectItem>
-          </SelectContent>
-        </Select>
-        {errors.budget && (
-          <div className="flex items-center mt-1 text-red-600 text-sm">
-            <AlertCircle className="h-4 w-4 mr-1" />
-            {errors.budget}
-          </div>
-        )}
+        <Tooltip open={!!errors.budget && touched.budget}>
+          <TooltipTrigger asChild>
+            <Select
+              value={formData.budget}
+              onValueChange={value => updateFormData('budget', value)}
+            >
+              <SelectTrigger
+                onBlur={() => handleBlur('budget')}
+                className={`border-gray-300 focus:border-bdigital-cyan ${errors.budget && touched.budget ? 'border-red-500' : ''}`}
+              >
+                <SelectValue placeholder={t('form.placeholder_budget')} />
+              </SelectTrigger>
+              <SelectContent forceMount>
+                <SelectItem value="under-1000">{t('form.budget_option.under_1000')}</SelectItem>
+                <SelectItem value="1000-2500">{t('form.budget_option.1000_2500')}</SelectItem>
+                <SelectItem value="2500-5000">{t('form.budget_option.2500_5000')}</SelectItem>
+                <SelectItem value="5000-10000">{t('form.budget_option.5000_10000')}</SelectItem>
+                <SelectItem value="over-10000">{t('form.budget_option.over_10000')}</SelectItem>
+                <SelectItem value="discuss">{t('form.budget_option.discuss')}</SelectItem>
+              </SelectContent>
+            </Select>
+          </TooltipTrigger>
+          <TooltipContent side="right">{errors.budget}</TooltipContent>
+        </Tooltip>
       </div>
 
       <div>

--- a/src/components/serviceInquirySteps/Step4.tsx
+++ b/src/components/serviceInquirySteps/Step4.tsx
@@ -3,17 +3,26 @@ import { Label } from '../ui/label';
 import { RadioGroup, RadioGroupItem } from '../ui/radio-group';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Textarea } from '../ui/textarea';
-import { AlertCircle, MessageSquare } from 'lucide-react';
+import { MessageSquare } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 import { useLanguage } from '../LanguageContext';
 import type { InquiryFormData } from '../ServiceInquiryForm';
 
 interface Step4Props {
   formData: InquiryFormData;
   errors: Record<string, string>;
+  touched: Record<string, boolean>;
   updateFormData: (field: keyof InquiryFormData, value: unknown) => void;
+  handleBlur: (field: keyof InquiryFormData) => void;
 }
 
-export function Step4({ formData, errors, updateFormData }: Step4Props) {
+export function Step4({
+  formData,
+  errors,
+  touched,
+  updateFormData,
+  handleBlur
+}: Step4Props) {
   const { t } = useLanguage();
 
   return (
@@ -22,14 +31,17 @@ export function Step4({ formData, errors, updateFormData }: Step4Props) {
         <Label className="mb-3 block text-bdigital-navy">
           {t('form.preferred_contact_label')}
         </Label>
-        <RadioGroup
-          value={formData.preferredContact}
-          onValueChange={value => updateFormData('preferredContact', value)}
-        >
-          <div className="flex items-center space-x-2">
-            <RadioGroupItem value="email" />
-            <Label className="text-neutral-gray">{t('form.contact_option.email')}</Label>
-          </div>
+        <Tooltip open={!!errors.preferredContact && touched.preferredContact}>
+          <TooltipTrigger asChild>
+            <RadioGroup
+              value={formData.preferredContact}
+              onValueChange={value => updateFormData('preferredContact', value)}
+              onBlur={() => handleBlur('preferredContact')}
+            >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="email" />
+                <Label className="text-neutral-gray">{t('form.contact_option.email')}</Label>
+              </div>
           <div className="flex items-center space-x-2">
             <RadioGroupItem value="phone" />
             <Label className="text-neutral-gray">{t('form.contact_option.phone')}</Label>
@@ -42,13 +54,10 @@ export function Step4({ formData, errors, updateFormData }: Step4Props) {
             <RadioGroupItem value="meeting" />
             <Label className="text-neutral-gray">{t('form.contact_option.meeting')}</Label>
           </div>
-        </RadioGroup>
-        {errors.preferredContact && (
-          <div className="flex items-center mt-2 text-red-600 text-sm">
-            <AlertCircle className="h-4 w-4 mr-1" />
-            {errors.preferredContact}
-          </div>
-        )}
+            </RadioGroup>
+          </TooltipTrigger>
+          <TooltipContent side="right">{errors.preferredContact}</TooltipContent>
+        </Tooltip>
       </div>
 
       <div>


### PR DESCRIPTION
## Summary
- validate form fields on change and blur
- show errors with tooltip beside the fields
- store touched state to control tooltip visibility
- add localization support in validation messages

## Testing
- `npm run lint` *(fails: Unexpected any in unrelated UI files)*

------
https://chatgpt.com/codex/tasks/task_e_688b6110d49c8323890c0b748eec6a82