### PR TITLE
feat: add contact API

### DIFF
--- a/backend-temp/src/routes/contact.ts
+++ b/backend-temp/src/routes/contact.ts
@@ -1,0 +1,36 @@
+import express from 'express';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const router = express.Router();
+
+router.post('/', async (req, res) => {
+  const { name, email, company, phone, message } = req.body;
+  const errors: Record<string, string> = {};
+
+  if (!name) {
+    errors.name = 'Name is required';
+  }
+  if (!email) {
+    errors.email = 'Email is required';
+  }
+  if (!message) {
+    errors.message = 'Message is required';
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return res.status(400).json({ errors });
+  }
+
+  try {
+    await prisma.contactMessage.create({
+      data: { name, email, company, phone, message },
+    });
+    return res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ errors: { server: 'Failed to save message' } });
+  }
+});
+
+export default router;

--- a/backend-temp/src/server.ts
+++ b/backend-temp/src/server.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import cors from 'cors';
+import contactRouter from './routes/contact';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -9,6 +10,7 @@ const app = express();
 const allowedOrigin = process.env.FRONTEND_URL || 'http://localhost:5173';
 app.use(cors({ origin: allowedOrigin }));
 app.use(express.json());
+app.use('/api/contact', contactRouter);
 
 const PORT = process.env.PORT || 3000;
 


### PR DESCRIPTION
## Summary
- add contact route to store messages via Prisma
- mount contact API route in server

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any, only-export-components)
- `cd backend-temp && npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68907923e3608323877b3b66c0868228