### PR TITLE
feat: add service inquiry endpoint

### DIFF
--- a/backend-temp/src/routes/serviceInquiry.ts
+++ b/backend-temp/src/routes/serviceInquiry.ts
@@ -1,0 +1,47 @@
+import express from 'express';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const router = express.Router();
+
+interface InquiryFormData {
+  fullName: string;
+  email: string;
+  phone: string;
+  company: string;
+  website: string;
+  selectedService: string;
+  selectedPackage: string;
+  projectTypes: string[];
+  currentSituation: string;
+  projectGoals: string;
+  targetAudience: string;
+  timeline: string;
+  budget: string;
+  additionalServices: string[];
+  preferredContact: string;
+  additionalInfo: string;
+  howDidYouHear: string;
+  newsletter: boolean;
+}
+
+router.post('/', async (req, res) => {
+  const data = req.body as InquiryFormData;
+
+  try {
+    await prisma.serviceInquiry.create({
+      data: {
+        ...data,
+        projectTypes: data.projectTypes ?? [],
+        additionalServices: data.additionalServices ?? [],
+      },
+    });
+
+    return res.json({ message: 'Service inquiry submitted successfully' });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ error: 'Failed to submit service inquiry' });
+  }
+});
+
+export default router;

--- a/backend-temp/src/server.ts
+++ b/backend-temp/src/server.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import contactRouter from './routes/contact';
+import serviceInquiryRouter from './routes/serviceInquiry';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -11,6 +12,7 @@ const allowedOrigin = process.env.FRONTEND_URL || 'http://localhost:5173';
 app.use(cors({ origin: allowedOrigin }));
 app.use(express.json());
 app.use('/api/contact', contactRouter);
+app.use('/api/service-inquiries', serviceInquiryRouter);
 
 const PORT = process.env.PORT || 3000;
 


### PR DESCRIPTION
## Summary
- add service inquiry route to persist InquiryFormData via Prisma
- register service inquiry API route in server

## Testing
- `npm run lint` *(fails: Unexpected any in chart.tsx, etc.)*
- `npx eslint backend-temp/src/routes/serviceInquiry.ts backend-temp/src/server.ts`

------
https://chatgpt.com/codex/tasks/task_e_68907b4ef21c83238ff245d1694a1e01