### PR TITLE
feat: add consultation request API route

### DIFF
--- a/backend-temp/src/routes/consultation.ts
+++ b/backend-temp/src/routes/consultation.ts
@@ -1,0 +1,41 @@
+import express from 'express';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const router = express.Router();
+
+interface ConsultationFormData {
+  fullName: string;
+  email: string;
+  phone: string;
+  company: string;
+  website: string;
+  businessType: string;
+  currentChallenges: string;
+  goals: string;
+  interestedServices: string[];
+  preferredContact: string;
+  preferredTime: string;
+  additionalInfo: string;
+  newsletter: boolean;
+}
+
+router.post('/', async (req, res) => {
+  const data = req.body as ConsultationFormData;
+
+  try {
+    await prisma.consultationRequest.create({
+      data: {
+        ...data,
+        interestedServices: data.interestedServices ?? [],
+      },
+    });
+
+    return res.json({ success: true });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ error: 'Failed to submit consultation request' });
+  }
+});
+
+export default router;

--- a/backend-temp/src/server.ts
+++ b/backend-temp/src/server.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import contactRouter from './routes/contact';
 import serviceInquiryRouter from './routes/serviceInquiry';
+import consultationRouter from './routes/consultation';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -13,6 +14,7 @@ app.use(cors({ origin: allowedOrigin }));
 app.use(express.json());
 app.use('/api/contact', contactRouter);
 app.use('/api/service-inquiries', serviceInquiryRouter);
+app.use('/api/consultations', consultationRouter);
 
 const PORT = process.env.PORT || 3000;
 


### PR DESCRIPTION
## Summary
- add express route to store consultation requests
- wire up consultations router in server

## Testing
- `cd backend-temp && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68907c89e0c88323a976d1704bc11c8f