### PR TITLE
Replace simulated delays with API requests

### DIFF
--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -29,28 +29,49 @@ export function ContactSection() {
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
-    
-    // Simulate form submission
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
-    setIsSubmitted(true);
-    setIsSubmitting(false);
-    
-    // Reset form after 3 seconds
-    setTimeout(() => {
-      setIsSubmitted(false);
-      setFormData({
-        name: '',
-        email: '',
-        company: '',
-        message: '',
-        phone: ''
+    setError(null);
+
+    try {
+      const response = await fetch('/api/contact', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(formData)
       });
-    }, 3000);
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        const message = data?.errors
+          ? Object.values(data.errors).join(', ')
+          : 'Failed to send message';
+        throw new Error(message);
+      }
+
+      setIsSubmitted(true);
+
+      // Reset form after 3 seconds
+      setTimeout(() => {
+        setIsSubmitted(false);
+        setFormData({
+          name: '',
+          email: '',
+          company: '',
+          message: '',
+          phone: ''
+        });
+      }, 3000);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to send message';
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleChange = (field: string, value: string) => {
@@ -230,6 +251,9 @@ export function ContactSection() {
                       </>
                     )}
                   </Button>
+                  {error && (
+                    <p className="text-red-500 text-sm text-center mt-4">{error}</p>
+                  )}
                 </form>
               )}
             </CardContent>

--- a/src/components/FreeConsultationPage.tsx
+++ b/src/components/FreeConsultationPage.tsx
@@ -50,6 +50,7 @@ export function FreeConsultationPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const [formData, setFormData] = useState<ConsultationFormData>({
     fullName: '',
@@ -113,14 +114,32 @@ export function FreeConsultationPage() {
 
   const handleSubmit = async () => {
     if (!validateForm()) return;
-    
+
     setIsSubmitting(true);
-    
-    // Simulate form submission
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
-    setIsSubmitting(false);
-    setIsSubmitted(true);
+    setSubmitError(null);
+
+    try {
+      const response = await fetch('/api/consultations', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(formData)
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        const message = data?.error || 'Failed to submit consultation request';
+        throw new Error(message);
+      }
+
+      setIsSubmitted(true);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to submit consultation request';
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   if (isSubmitted) {
@@ -557,6 +576,9 @@ export function FreeConsultationPage() {
                 <p className="text-center text-sm text-neutral-gray mt-3">
                   Kontaktiraćemo vas u roku od 24 sata da potvrdimo termin
                 </p>
+                {submitError && (
+                  <p className="text-red-500 text-sm text-center mt-4">{submitError}</p>
+                )}
               </div>
             </div>
           </CardContent>

--- a/src/components/ServiceInquiryForm.tsx
+++ b/src/components/ServiceInquiryForm.tsx
@@ -70,6 +70,7 @@ export function ServiceInquiryForm() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const [formData, setFormData] = useState<InquiryFormData>({
     fullName: '',
@@ -219,18 +220,36 @@ export function ServiceInquiryForm() {
 
   const handleSubmit = async () => {
     if (!validateStep(4)) return;
-    
+
     setIsSubmitting(true);
-    
-    // Simulate form submission
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    
-    setIsSubmitting(false);
-    setIsSubmitted(true);
-    
-    // Clear stored service/package info
-    localStorage.removeItem('selectedService');
-    localStorage.removeItem('selectedPackage');
+    setSubmitError(null);
+
+    try {
+      const response = await fetch('/api/service-inquiries', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(formData)
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        const message = data?.error || 'Failed to submit inquiry';
+        throw new Error(message);
+      }
+
+      setIsSubmitted(true);
+
+      // Clear stored service/package info
+      localStorage.removeItem('selectedService');
+      localStorage.removeItem('selectedPackage');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to submit inquiry';
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const nextStep = () => {
@@ -542,6 +561,9 @@ export function ServiceInquiryForm() {
                 </Button>
               )}
             </div>
+            {submitError && (
+              <p className="text-red-500 text-sm text-center mt-4">{submitError}</p>
+            )}
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- switch contact form to POST `/api/contact` and surface any server errors
- submit service inquiries via `/api/service-inquiries` with error handling
- wire free consultation form to `/api/consultations` and show submission failures

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: react-refresh/only-export-components, no-unused-vars, @typescript-eslint/no-explicit-any)


------
https://chatgpt.com/codex/tasks/task_e_68907db20e5c8323acd104c20705fbb1