### PR TITLE
Add Nodemailer email service

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,15 @@ export default tseslint.config([
   },
 ])
 ```
+
+## Backend Environment Variables
+
+The backend email service uses the following environment variables:
+
+- `SMTP_HOST` – SMTP server host
+- `SMTP_PORT` – SMTP server port
+- `SMTP_USER` – SMTP username
+- `SMTP_PASS` – SMTP password
+- `EMAIL_FROM` – sender address used in emails
+- `EMAIL_TO` – destination address for form submissions
+

--- a/backend-temp/package.json
+++ b/backend-temp/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^16.4.5",
     "prisma": "^5.14.0",
     "@prisma/client": "^5.14.0",
-    "mysql2": "^3.11.4"
+    "mysql2": "^3.11.4",
+    "nodemailer": "^6.9.9"
   }
 }

--- a/backend-temp/src/utils/emailService.ts
+++ b/backend-temp/src/utils/emailService.ts
@@ -1,0 +1,74 @@
+import nodemailer from 'nodemailer';
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: Number(process.env.SMTP_PORT),
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+});
+
+type Language = 'me' | 'en';
+type Payload = Record<string, string>;
+
+const locales = {
+  contact: {
+    subject: {
+      me: 'Nova poruka sa kontakt forme',
+      en: 'New contact form message',
+    },
+    body: {
+      me: (p: Payload) => `Ime: ${p.name}\nEmail: ${p.email}\nPoruka: ${p.message}`,
+      en: (p: Payload) => `Name: ${p.name}\nEmail: ${p.email}\nMessage: ${p.message}`,
+    },
+  },
+  consultation: {
+    subject: {
+      me: 'Zahtev za konsultaciju',
+      en: 'Consultation request',
+    },
+    body: {
+      me: (p: Payload) => `Ime: ${p.name}\nEmail: ${p.email}\nTelefon: ${p.phone}`,
+      en: (p: Payload) => `Name: ${p.name}\nEmail: ${p.email}\nPhone: ${p.phone}`,
+    },
+  },
+  serviceInquiry: {
+    subject: {
+      me: 'Upit za uslugu',
+      en: 'Service inquiry',
+    },
+    body: {
+      me: (p: Payload) => `Ime: ${p.name}\nUsluga: ${p.service}\nDetalji: ${p.details}`,
+      en: (p: Payload) => `Name: ${p.name}\nService: ${p.service}\nDetails: ${p.details}`,
+    },
+  },
+};
+
+export async function sendContactEmail(payload: Payload, language: Language) {
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM,
+    to: process.env.EMAIL_TO,
+    subject: locales.contact.subject[language],
+    text: locales.contact.body[language](payload),
+  });
+}
+
+export async function sendConsultationEmail(payload: Payload, language: Language) {
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM,
+    to: process.env.EMAIL_TO,
+    subject: locales.consultation.subject[language],
+    text: locales.consultation.body[language](payload),
+  });
+}
+
+export async function sendServiceInquiryEmail(payload: Payload, language: Language) {
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM,
+    to: process.env.EMAIL_TO,
+    subject: locales.serviceInquiry.subject[language],
+    text: locales.serviceInquiry.body[language](payload),
+  });
+}
+


### PR DESCRIPTION
## Summary
- add `nodemailer` dependency for backend
- implement reusable email service with localized subjects/bodies
- document SMTP environment variables

## Testing
- `cd backend-temp && npm test` (fails: Error: no test specified)
- `npm test` (fails: Missing script: test)
- `npm run lint` (fails: 14 errors)

------
https://chatgpt.com/codex/tasks/task_e_68908ad23af88323aa719a4a1c90cc4f