### PR TITLE
Send localized confirmation emails for form submissions

### DIFF
--- a/backend-temp/src/utils/emailService.ts
+++ b/backend-temp/src/utils/emailService.ts
@@ -14,33 +14,74 @@ type Payload = Record<string, string>;
 
 const locales = {
   contact: {
-    subject: {
-      me: 'Nova poruka sa kontakt forme',
-      en: 'New contact form message',
+    internal: {
+      subject: {
+        me: 'Nova poruka sa kontakt forme',
+        en: 'New contact form message',
+      },
+      body: {
+        me: (p: Payload) => `Ime: ${p.name}\nEmail: ${p.email}\nPoruka: ${p.message}`,
+        en: (p: Payload) => `Name: ${p.name}\nEmail: ${p.email}\nMessage: ${p.message}`,
+      },
     },
-    body: {
-      me: (p: Payload) => `Ime: ${p.name}\nEmail: ${p.email}\nPoruka: ${p.message}`,
-      en: (p: Payload) => `Name: ${p.name}\nEmail: ${p.email}\nMessage: ${p.message}`,
+    confirmation: {
+      subject: {
+        me: 'Potvrda kontakt poruke',
+        en: 'Contact message received',
+      },
+      body: {
+        me: (p: Payload) =>
+          `Poštovani ${p.name}, hvala što ste nas kontaktirali. Vaša poruka je primljena.`,
+        en: (p: Payload) =>
+          `Dear ${p.name}, thank you for contacting us. We have received your message.`,
+      },
     },
   },
   consultation: {
-    subject: {
-      me: 'Zahtev za konsultaciju',
-      en: 'Consultation request',
+    internal: {
+      subject: {
+        me: 'Zahtev za konsultaciju',
+        en: 'Consultation request',
+      },
+      body: {
+        me: (p: Payload) => `Ime: ${p.name}\nEmail: ${p.email}\nTelefon: ${p.phone}`,
+        en: (p: Payload) => `Name: ${p.name}\nEmail: ${p.email}\nPhone: ${p.phone}`,
+      },
     },
-    body: {
-      me: (p: Payload) => `Ime: ${p.name}\nEmail: ${p.email}\nTelefon: ${p.phone}`,
-      en: (p: Payload) => `Name: ${p.name}\nEmail: ${p.email}\nPhone: ${p.phone}`,
+    confirmation: {
+      subject: {
+        me: 'Potvrda zahteva za konsultaciju',
+        en: 'Consultation request received',
+      },
+      body: {
+        me: () =>
+          'Vaš zahtev za konsultaciju je primljen. Uskoro ćemo vas kontaktirati.',
+        en: () =>
+          'Your consultation request has been received. We will contact you soon.',
+      },
     },
   },
   serviceInquiry: {
-    subject: {
-      me: 'Upit za uslugu',
-      en: 'Service inquiry',
+    internal: {
+      subject: {
+        me: 'Upit za uslugu',
+        en: 'Service inquiry',
+      },
+      body: {
+        me: (p: Payload) => `Ime: ${p.name}\nUsluga: ${p.service}\nDetalji: ${p.details}`,
+        en: (p: Payload) => `Name: ${p.name}\nService: ${p.service}\nDetails: ${p.details}`,
+      },
     },
-    body: {
-      me: (p: Payload) => `Ime: ${p.name}\nUsluga: ${p.service}\nDetalji: ${p.details}`,
-      en: (p: Payload) => `Name: ${p.name}\nService: ${p.service}\nDetails: ${p.details}`,
+    confirmation: {
+      subject: {
+        me: 'Potvrda upita za uslugu',
+        en: 'Service inquiry received',
+      },
+      body: {
+        me: () =>
+          'Vaš upit za uslugu je primljen. Uskoro ćemo vam odgovoriti.',
+        en: () => 'Your service inquiry has been received. We will reply shortly.',
+      },
     },
   },
 };
@@ -49,8 +90,14 @@ export async function sendContactEmail(payload: Payload, language: Language) {
   await transporter.sendMail({
     from: process.env.EMAIL_FROM,
     to: process.env.EMAIL_TO,
-    subject: locales.contact.subject[language],
-    text: locales.contact.body[language](payload),
+    subject: locales.contact.internal.subject[language],
+    text: locales.contact.internal.body[language](payload),
+  });
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM,
+    to: payload.email,
+    subject: locales.contact.confirmation.subject[language],
+    text: locales.contact.confirmation.body[language](payload),
   });
 }
 
@@ -58,8 +105,14 @@ export async function sendConsultationEmail(payload: Payload, language: Language
   await transporter.sendMail({
     from: process.env.EMAIL_FROM,
     to: process.env.EMAIL_TO,
-    subject: locales.consultation.subject[language],
-    text: locales.consultation.body[language](payload),
+    subject: locales.consultation.internal.subject[language],
+    text: locales.consultation.internal.body[language](payload),
+  });
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM,
+    to: payload.email,
+    subject: locales.consultation.confirmation.subject[language],
+    text: locales.consultation.confirmation.body[language](payload),
   });
 }
 
@@ -67,8 +120,14 @@ export async function sendServiceInquiryEmail(payload: Payload, language: Langua
   await transporter.sendMail({
     from: process.env.EMAIL_FROM,
     to: process.env.EMAIL_TO,
-    subject: locales.serviceInquiry.subject[language],
-    text: locales.serviceInquiry.body[language](payload),
+    subject: locales.serviceInquiry.internal.subject[language],
+    text: locales.serviceInquiry.internal.body[language](payload),
+  });
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM,
+    to: payload.email,
+    subject: locales.serviceInquiry.confirmation.subject[language],
+    text: locales.serviceInquiry.confirmation.body[language](payload),
   });
 }
 


### PR DESCRIPTION
## Summary
- send internal notification and confirmation emails for contact form
- send localized notification/confirmation emails for consultation request
- send service inquiry emails with user confirmation
- extend email service with localized confirmation templates

## Testing
- `npm --prefix backend-temp test` *(fails: Error: no test specified)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 14 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68908c7f3fe483239240be20467459a1