### PR TITLE
Include language with form submissions

### DIFF
--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -19,7 +19,7 @@ import { useLanguage } from './LanguageContext';
 import { EMAIL, PHONE, ADDRESS } from '../config/contact';
 
 export function ContactSection() {
-  const { t: _t } = useLanguage();
+  const { t: _t, language } = useLanguage();
   const [formData, setFormData] = useState({
     name: '',
     email: '',
@@ -42,7 +42,7 @@ export function ContactSection() {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify(formData)
+        body: JSON.stringify({ ...formData, language })
       });
 
       if (!response.ok) {

--- a/src/components/FreeConsultationPage.tsx
+++ b/src/components/FreeConsultationPage.tsx
@@ -46,7 +46,7 @@ interface ConsultationFormData {
 
 export function FreeConsultationPage() {
   const { navigateTo } = useRouter();
-  const { t } = useLanguage();
+  const { t, language } = useLanguage();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -124,7 +124,7 @@ export function FreeConsultationPage() {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify(formData)
+        body: JSON.stringify({ ...formData, language })
       });
 
       if (!response.ok) {

--- a/src/components/ServiceInquiryForm.tsx
+++ b/src/components/ServiceInquiryForm.tsx
@@ -58,7 +58,7 @@ export interface InquiryFormData {
 }
 export function ServiceInquiryForm() {
   const { navigateTo } = useRouter();
-  const { t } = useLanguage();
+  const { t, language } = useLanguage();
   const [currentStep, setCurrentStep] = useState(1);
   const serviceInfo: Record<string, { title: string; description: string; icon: string }> = {
     "web-design": { title: t("services.web.title"), description: t("services.web.desc"), icon: "🎨" },
@@ -230,7 +230,7 @@ export function ServiceInquiryForm() {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify(formData)
+        body: JSON.stringify({ ...formData, language })
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- include `language` from `useLanguage` in ContactSection, FreeConsultationPage, and ServiceInquiryForm
- send selected language with each API request for proper backend localization

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors in existing files)*


------
https://chatgpt.com/codex/tasks/task_e_68908e1a3c888323bcf374ad126a8b1c