### PR TITLE
chore: use localized email templates

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -504,6 +504,12 @@
   "branding.package.enterprise.feature4": "Complete identity",
   "branding.package.enterprise.feature5": "12 months support",
   "inquiry.title": "Request a quote",
-  "inquiry.subtitle": "Fill out the form below so we can prepare a personalized quote for your project."
+  "inquiry.subtitle": "Fill out the form below so we can prepare a personalized quote for your project.",
+  "email.contact.subject": "New contact form message",
+  "email.contact.body": "Name: {name}\\nEmail: {email}\\nMessage: {message}",
+  "email.consultation.subject": "Consultation request",
+  "email.consultation.body": "Name: {name}\\nEmail: {email}\\nPhone: {phone}",
+  "email.inquiry.subject": "Service inquiry",
+  "email.inquiry.body": "Name: {name}\\nService: {service}\\nDetails: {details}"
 }
 

--- a/src/locales/me.json
+++ b/src/locales/me.json
@@ -505,6 +505,12 @@
   "branding.package.enterprise.feature4": "Kompletan identitet",
   "branding.package.enterprise.feature5": "12 meseci podrška",
   "inquiry.title": "Upit za ponudu",
-  "inquiry.subtitle": "Popunite formu ispod da bismo pripremili personalizovanu ponudu za vaš projekat."
+  "inquiry.subtitle": "Popunite formu ispod da bismo pripremili personalizovanu ponudu za vaš projekat.",
+  "email.contact.subject": "Nova poruka sa kontakt forme",
+  "email.contact.body": "Ime: {name}\\nEmail: {email}\\nPoruka: {message}",
+  "email.consultation.subject": "Zahtev za konsultaciju",
+  "email.consultation.body": "Ime: {name}\\nEmail: {email}\\nTelefon: {phone}",
+  "email.inquiry.subject": "Upit za uslugu",
+  "email.inquiry.body": "Ime: {name}\\nUsluga: {service}\\nDetalji: {details}"
 }
 


### PR DESCRIPTION
## Summary
- add email template strings to English and Montenegrin locales
- load email templates from locales when composing messages

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npx eslint backend-temp/src/utils/emailService.ts`

------
https://chatgpt.com/codex/tasks/task_e_68908fa862d88323a5bd021bdd7e80e0