### PR TITLE
Include company and phone in contact emails

### DIFF
--- a/backend-temp/src/utils/emailService.ts
+++ b/backend-temp/src/utils/emailService.ts
@@ -65,17 +65,27 @@ const confirmationLocales = {
 };
 
 export async function sendContactEmail(payload: Payload, language: Language) {
+  const body = format(t(language, "email.contact.body"), {
+    name: payload.name,
+    email: payload.email,
+    company: payload.company,
+    phone: payload.phone,
+    message: payload.message,
+  });
   await transporter.sendMail({
     from: process.env.EMAIL_FROM,
     to: process.env.EMAIL_TO,
     subject: t(language, "email.contact.subject"),
-    text: format(t(language, "email.contact.body"), payload),
+    text: body,
+    html: body.replace(/\n/g, "<br/>"),
   });
+  const confirmationBody = confirmationLocales.contact.body[language](payload);
   await transporter.sendMail({
     from: process.env.EMAIL_FROM,
     to: payload.email,
     subject: confirmationLocales.contact.subject[language],
-    text: confirmationLocales.contact.body[language](payload),
+    text: confirmationBody,
+    html: `<p>${confirmationBody}</p>`,
   });
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -506,7 +506,7 @@
   "inquiry.title": "Request a quote",
   "inquiry.subtitle": "Fill out the form below so we can prepare a personalized quote for your project.",
   "email.contact.subject": "New contact form message",
-  "email.contact.body": "Name: {name}\\nEmail: {email}\\nMessage: {message}",
+  "email.contact.body": "Name: {name}\\nEmail: {email}\\nCompany: {company}\\nPhone: {phone}\\nMessage: {message}",
   "email.consultation.subject": "Consultation request",
   "email.consultation.body": "Name: {name}\\nEmail: {email}\\nPhone: {phone}",
   "email.inquiry.subject": "Service inquiry",

--- a/src/locales/me.json
+++ b/src/locales/me.json
@@ -507,7 +507,7 @@
   "inquiry.title": "Upit za ponudu",
   "inquiry.subtitle": "Popunite formu ispod da bismo pripremili personalizovanu ponudu za vaš projekat.",
   "email.contact.subject": "Nova poruka sa kontakt forme",
-  "email.contact.body": "Ime: {name}\\nEmail: {email}\\nPoruka: {message}",
+  "email.contact.body": "Ime: {name}\\nEmail: {email}\\nKompanija: {company}\\nTelefon: {phone}\\nPoruka: {message}",
   "email.consultation.subject": "Zahtev za konsultaciju",
   "email.consultation.body": "Ime: {name}\\nEmail: {email}\\nTelefon: {phone}",
   "email.inquiry.subject": "Upit za uslugu",


### PR DESCRIPTION
## Summary
- extend contact email templates with company and phone placeholders
- send formatted contact emails including HTML version

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react-refresh/only-export-components, no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_6890a7e151ac8323ac5d71186f90efa4