### PR TITLE
Include full consultation details in emails

### DIFF
--- a/backend-temp/src/routes/consultation.ts
+++ b/backend-temp/src/routes/consultation.ts
@@ -40,6 +40,22 @@ router.post('/', async (req, res) => {
           name: formData.fullName,
           email: formData.email,
           phone: formData.phone,
+          company: formData.company,
+          website: formData.website,
+          businessType: formData.businessType,
+          currentChallenges: formData.currentChallenges,
+          goals: formData.goals,
+          interestedServices: formData.interestedServices.join(', '),
+          preferredContact: formData.preferredContact,
+          preferredTime: formData.preferredTime,
+          additionalInfo: formData.additionalInfo,
+          newsletter: formData.newsletter
+            ? language === 'me'
+              ? 'Da'
+              : 'Yes'
+            : language === 'me'
+              ? 'Ne'
+              : 'No',
         },
         language,
       );

--- a/backend-temp/src/utils/emailService.ts
+++ b/backend-temp/src/utils/emailService.ts
@@ -90,17 +90,21 @@ export async function sendContactEmail(payload: Payload, language: Language) {
 }
 
 export async function sendConsultationEmail(payload: Payload, language: Language) {
+  const body = format(t(language, "email.consultation.body"), payload);
   await transporter.sendMail({
     from: process.env.EMAIL_FROM,
     to: process.env.EMAIL_TO,
     subject: t(language, "email.consultation.subject"),
-    text: format(t(language, "email.consultation.body"), payload),
+    text: body,
+    html: body.split("\n").map((line) => `<p>${line}</p>`).join(""),
   });
+  const confirmationBody = confirmationLocales.consultation.body[language](payload);
   await transporter.sendMail({
     from: process.env.EMAIL_FROM,
     to: payload.email,
     subject: confirmationLocales.consultation.subject[language],
-    text: confirmationLocales.consultation.body[language](payload),
+    text: confirmationBody,
+    html: `<p>${confirmationBody}</p>`,
   });
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -508,7 +508,7 @@
   "email.contact.subject": "New contact form message",
   "email.contact.body": "Name: {name}\\nEmail: {email}\\nCompany: {company}\\nPhone: {phone}\\nMessage: {message}",
   "email.consultation.subject": "Consultation request",
-  "email.consultation.body": "Name: {name}\\nEmail: {email}\\nPhone: {phone}",
+  "email.consultation.body": "Name: {name}\\nEmail: {email}\\nPhone: {phone}\\nCompany: {company}\\nWebsite: {website}\\nBusiness Type: {businessType}\\nCurrent Challenges: {currentChallenges}\\nGoals: {goals}\\nInterested Services: {interestedServices}\\nPreferred Contact: {preferredContact}\\nPreferred Time: {preferredTime}\\nAdditional Info: {additionalInfo}\\nNewsletter: {newsletter}",
   "email.inquiry.subject": "Service inquiry",
   "email.inquiry.body": "Name: {name}\\nService: {service}\\nDetails: {details}"
 }

--- a/src/locales/me.json
+++ b/src/locales/me.json
@@ -509,7 +509,7 @@
   "email.contact.subject": "Nova poruka sa kontakt forme",
   "email.contact.body": "Ime: {name}\\nEmail: {email}\\nKompanija: {company}\\nTelefon: {phone}\\nPoruka: {message}",
   "email.consultation.subject": "Zahtev za konsultaciju",
-  "email.consultation.body": "Ime: {name}\\nEmail: {email}\\nTelefon: {phone}",
+  "email.consultation.body": "Ime: {name}\\nEmail: {email}\\nTelefon: {phone}\\nKompanija: {company}\\nWebsite: {website}\\nTip biznisa: {businessType}\\nTrenutni izazovi: {currentChallenges}\\nCiljevi: {goals}\\nZainteresovane usluge: {interestedServices}\\nPreferirani kontakt: {preferredContact}\\nPreferirano vrijeme: {preferredTime}\\nDodatne informacije: {additionalInfo}\\nNewsletter: {newsletter}",
   "email.inquiry.subject": "Upit za uslugu",
   "email.inquiry.body": "Ime: {name}\\nUsluga: {service}\\nDetalji: {details}"
 }


### PR DESCRIPTION
## Summary
- expand consultation translation strings to list every field submitted via the form
- forward all consultation form fields to the email service and format newsletter response per locale
- send admin consultation emails with HTML-formatted field list and send HTML confirmation to requester

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 14 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6890a985fc5c832388f651dd389653d5