### PR TITLE
Expand service inquiry emails

### DIFF
--- a/backend-temp/src/routes/serviceInquiry.ts
+++ b/backend-temp/src/routes/serviceInquiry.ts
@@ -41,15 +41,7 @@ router.post('/', async (req, res) => {
     });
 
     try {
-      await sendServiceInquiryEmail(
-        {
-          name: formData.fullName,
-          email: formData.email,
-          service: formData.selectedService,
-          details: formData.projectGoals,
-        },
-        language,
-      );
+      await sendServiceInquiryEmail(formData, language);
     } catch (emailErr) {
       console.error('Failed to send service inquiry emails', emailErr);
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -510,6 +510,6 @@
   "email.consultation.subject": "Consultation request",
   "email.consultation.body": "Name: {name}\\nEmail: {email}\\nPhone: {phone}\\nCompany: {company}\\nWebsite: {website}\\nBusiness Type: {businessType}\\nCurrent Challenges: {currentChallenges}\\nGoals: {goals}\\nInterested Services: {interestedServices}\\nPreferred Contact: {preferredContact}\\nPreferred Time: {preferredTime}\\nAdditional Info: {additionalInfo}\\nNewsletter: {newsletter}",
   "email.inquiry.subject": "Service inquiry",
-  "email.inquiry.body": "Name: {name}\\nService: {service}\\nDetails: {details}"
+  "email.inquiry.body": "Full Name: {fullName}\\nEmail: {email}\\nPhone: {phone}\\nCompany: {company}\\nWebsite: {website}\\nSelected Service: {selectedService}\\nSelected Package: {selectedPackage}\\nProject Types: {projectTypes}\\nCurrent Situation: {currentSituation}\\nProject Goals: {projectGoals}\\nTarget Audience: {targetAudience}\\nTimeline: {timeline}\\nBudget: {budget}\\nAdditional Services: {additionalServices}\\nPreferred Contact: {preferredContact}\\nAdditional Info: {additionalInfo}\\nHow Did You Hear: {howDidYouHear}\\nNewsletter: {newsletter}"
 }
 

--- a/src/locales/me.json
+++ b/src/locales/me.json
@@ -511,6 +511,6 @@
   "email.consultation.subject": "Zahtev za konsultaciju",
   "email.consultation.body": "Ime: {name}\\nEmail: {email}\\nTelefon: {phone}\\nKompanija: {company}\\nWebsite: {website}\\nTip biznisa: {businessType}\\nTrenutni izazovi: {currentChallenges}\\nCiljevi: {goals}\\nZainteresovane usluge: {interestedServices}\\nPreferirani kontakt: {preferredContact}\\nPreferirano vrijeme: {preferredTime}\\nDodatne informacije: {additionalInfo}\\nNewsletter: {newsletter}",
   "email.inquiry.subject": "Upit za uslugu",
-  "email.inquiry.body": "Ime: {name}\\nUsluga: {service}\\nDetalji: {details}"
+  "email.inquiry.body": "Ime i prezime: {fullName}\\nEmail: {email}\\nTelefon: {phone}\\nKompanija: {company}\\nWebsite: {website}\\nOdabrana usluga: {selectedService}\\nOdabrani paket: {selectedPackage}\\nTipovi projekata: {projectTypes}\\nTrenutna situacija: {currentSituation}\\nCiljevi projekta: {projectGoals}\\nCiljna publika: {targetAudience}\\nVremenski okvir: {timeline}\\nBudžet: {budget}\\nDodatne usluge: {additionalServices}\\nPreferirani kontakt: {preferredContact}\\nDodatne informacije: {additionalInfo}\\nKako ste čuli za nas: {howDidYouHear}\\nNewsletter: {newsletter}"
 }
 


### PR DESCRIPTION
## Summary
- add placeholders for all inquiry fields in locale files
- send full inquiry data to email service
- render inquiry emails as HTML tables and include confirmation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any & Fast refresh only works...)
- `npm --prefix backend-temp test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6890abaa35fc832381ed28485a444163