### PR TITLE
feat: persist selected language

### DIFF
--- a/src/components/LanguageContext.tsx
+++ b/src/components/LanguageContext.tsx
@@ -13,13 +13,19 @@ const LanguageContext = createContext<LanguageContextType | undefined>(undefined
 
 
 export function LanguageProvider({ children }: { children: ReactNode }) {
-  const [language, setLanguage] = useState<Language>('me');
+  const [language, setLanguage] = useState<Language>(
+    (localStorage.getItem('language') as Language) || 'me'
+  );
   const [translations, setTranslations] = useState<Record<string, string>>({});
 
   useEffect(() => {
     import(`../locales/${language}.json`).then((mod) => {
       setTranslations(mod.default);
     });
+  }, [language]);
+
+  useEffect(() => {
+    localStorage.setItem('language', language);
   }, [language]);
 
   const t = (key: string): string => {


### PR DESCRIPTION
## Summary
- initialize language from localStorage
- save current language to localStorage on change

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*
- `npx eslint src/components/LanguageContext.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689200ffd9088323848b23c5bc6e0b62