### PR TITLE
fix: use singular API endpoints

### DIFF
--- a/src/components/FreeConsultationPage.tsx
+++ b/src/components/FreeConsultationPage.tsx
@@ -119,7 +119,7 @@ export function FreeConsultationPage() {
     setSubmitError(null);
 
     try {
-      const response = await fetch('/api/consultations', {
+      const response = await fetch('/api/consultation', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/src/components/ServiceInquiryForm.tsx
+++ b/src/components/ServiceInquiryForm.tsx
@@ -225,7 +225,7 @@ export function ServiceInquiryForm() {
     setSubmitError(null);
 
     try {
-      const response = await fetch('/api/service-inquiries', {
+      const response = await fetch('/api/service-inquiry', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- align consultation form POST URL with singular backend endpoint
- send service inquiry data to updated `/api/service-inquiry` route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react-refresh/only-export-components, @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_689310cedc688323b0beccb3d91ffe8f