### PR TITLE
Add Vercel function mapping for serverless API routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/*": {
+      "source": "src/vercel/api/*.ts"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- configure Vercel to expose TypeScript functions under `/api/*` via `vercel.json`

## Testing
- `npm run lint` *(fails: 23 errors)*
- `npm run build` *(fails: Cannot find module '@vercel/node', missing types)
- `npx vercel dev` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68931389bb3c83238b8176e8faa1b4f0