### PR TITLE
feat: add prisma schema and env examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Environment variables for digitalMarketing project
+
+# Database connection string used by Prisma
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE"
+
+# SMTP configuration for email service
+SMTP_HOST=""
+SMTP_PORT=""
+SMTP_USER=""
+SMTP_PASS=""
+EMAIL_FROM=""
+EMAIL_TO=""

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ export default tseslint.config([
 
 ## Backend Environment Variables
 
-The backend email service uses the following environment variables:
+The project relies on the following environment variables:
 
+- `DATABASE_URL` – database connection string used by Prisma
 - `SMTP_HOST` – SMTP server host
 - `SMTP_PORT` – SMTP server port
 - `SMTP_USER` – SMTP username

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,41 @@
+// Prisma schema for digitalMarketing project
+
+// Data source definition
+ datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+ }
+
+ // Prisma Client generator
+ generator client {
+  provider = "prisma-client-js"
+ }
+
+ // Model for contact form submissions
+ model contactMessage {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String
+  message   String
+  createdAt DateTime @default(now())
+ }
+
+ // Model for consultation requests
+ model consultationRequest {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String
+  phone     String?
+  message   String?
+  createdAt DateTime @default(now())
+ }
+
+ // Model for service inquiries
+ model serviceInquiry {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String
+  service   String?
+  message   String?
+  createdAt DateTime @default(now())
+ }


### PR DESCRIPTION
## Summary
- set up Prisma schema with models for contact messages, consultation requests, and service inquiries
- document required environment variables and add example env file

## Testing
- `npx prisma generate`
- `npm run lint` *(fails: react-refresh/only-export-components, @typescript-eslint/no-explicit-any)*
- `npm run build` *(fails: missing module declarations and node types)*

------
https://chatgpt.com/codex/tasks/task_e_689314ae81e48323a9a6602e3a4d3439