### PR TITLE
chore: add Vercel build configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "functions": {
+    "src/vercel/api/*.ts": {
+      "runtime": "nodejs18.x"
+    }
+  },
+  "rewrites": [
+    {
+      "source": "/api/(.*)",
+      "destination": "/src/vercel/api/$1"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- define Vercel build command and output directory
- map API routes to serverless functions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 41 problems (41 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68932d6c67148323b0f04438c3d7285b