### PR TITLE
chore: move vercel api to root-level

### DIFF
--- a/api/consultation.ts
+++ b/api/consultation.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { PrismaClient } from "@prisma/client";
-import { sendConsultationEmail } from '../utils/emailService';
+import { sendConsultationEmail } from '../src/vercel/utils/emailService';
 
 const prisma = (globalThis as any).prisma ?? new PrismaClient();
 if (!(globalThis as any).prisma) {

--- a/api/contact.ts
+++ b/api/contact.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { PrismaClient } from "@prisma/client";
-import { sendContactEmail } from '../utils/emailService';
+import { sendContactEmail } from '../src/vercel/utils/emailService';
 
 const prisma = (globalThis as any).prisma ?? new PrismaClient();
 if (!(globalThis as any).prisma) {

--- a/api/service-inquiry.ts
+++ b/api/service-inquiry.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { PrismaClient } from "@prisma/client";
-import { sendServiceInquiryEmail } from "../utils/emailService";
+import { sendServiceInquiryEmail } from "../src/vercel/utils/emailService";
 
 interface InquiryFormData {
   fullName: string;

--- a/vercel.json
+++ b/vercel.json
@@ -2,14 +2,8 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "functions": {
-    "src/vercel/api/*.ts": {
+    "api/*.ts": {
       "runtime": "nodejs18.x"
     }
-  },
-  "rewrites": [
-    {
-      "source": "/api/(.*)",
-      "destination": "/src/vercel/api/$1"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- relocate Vercel serverless functions into a top-level `api` folder and update their imports
- configure Vercel to treat `api/*.ts` as serverless functions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 41 errors)*
- `npm run build` *(fails: TypeScript errors in select.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68932ee5dda88323b741b79dd516d8f4