### PR TITLE
refactor: import locale JSON statically

### DIFF
--- a/src/vercel/utils/emailService.ts
+++ b/src/vercel/utils/emailService.ts
@@ -1,6 +1,6 @@
 import nodemailer from "nodemailer";
-import { readFileSync } from "fs";
-import path from "path";
+import en from "../locales/en.json";
+import me from "../locales/me.json";
 
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
@@ -19,12 +19,8 @@ type Language = "me" | "en";
 type Payload = Record<string, string>;
 
 const translations: Record<Language, Record<string, string>> = {
-  en: JSON.parse(
-    readFileSync(path.join(__dirname, "../locales/en.json"), "utf-8")
-  ),
-  me: JSON.parse(
-    readFileSync(path.join(__dirname, "../locales/me.json"), "utf-8")
-  ),
+  en,
+  me,
 };
 
 function t(language: Language, key: string): string {


### PR DESCRIPTION
## Summary
- replace fs readFileSync with static JSON imports for email templates
- drop unused fs and path dependencies in emailService

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any and react-refresh errors in unrelated files)
- `npm run build` (fails: Type errors in src/components/ui/select.tsx)


------
https://chatgpt.com/codex/tasks/task_e_689330ba1b8c8323a2d0c44b5a885df0