### PR TITLE
chore: specify vercel runtime

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "outputDirectory": "dist",
   "functions": {
     "api/*.ts": {
-      "runtime": "nodejs18.x"
+      "runtime": "@vercel/node@5.3.11"
     }
   }
 }


### PR DESCRIPTION
## Summary
- specify @vercel/node runtime 5.3.11 in vercel.json

## Testing
- `npm run build` *(fails: Property 'forceMount' does not exist on type 'IntrinsicAttributes & SelectPortalProps'.)*
- `npx vercel build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_6893331c9a588323a1879b0620950ba5