### PR TITLE
Escape HTML entities in email payload tables

### DIFF
--- a/src/vercel/utils/emailService.test.ts
+++ b/src/vercel/utils/emailService.test.ts
@@ -1,0 +1,23 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import { buildHtmlTable } from "./htmlTable.js";
+
+test("buildHtmlTable escapes HTML special characters", () => {
+  const payload = {
+    'na<me&"': "value with <script>alert('x & \"y\"')</script>",
+  };
+  const html = buildHtmlTable(payload);
+
+  assert.ok(
+    html.includes('<strong>na&lt;me&amp;&quot;:</strong>'),
+    "Key was not escaped"
+  );
+  assert.ok(
+    html.includes(
+      'value with &lt;script&gt;alert(&#39;x &amp; &quot;y&quot;&#39;)&lt;/script&gt;'
+    ),
+    "Value was not escaped"
+  );
+  assert.ok(!html.includes("<script>"), "Unescaped script tag found");
+});
+

--- a/src/vercel/utils/emailService.ts
+++ b/src/vercel/utils/emailService.ts
@@ -1,6 +1,7 @@
 import nodemailer from "nodemailer";
 import en from "../locales/en.json";
 import me from "../locales/me.json";
+import { buildHtmlTable, type Payload } from "./htmlTable";
 
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
@@ -16,7 +17,6 @@ const transporter = nodemailer.createTransport({
 });
 
 type Language = "me" | "en";
-type Payload = Record<string, string>;
 
 const translations: Record<Language, Record<string, string>> = {
   en,
@@ -29,15 +29,6 @@ function t(language: Language, key: string): string {
 
 function format(template: string, payload: Payload) {
   return template.replace(/\{(\w+)\}/g, (_, k) => payload[k] ?? "");
-}
-
-function buildHtmlTable(payload: Payload) {
-  return `<table>${Object.entries(payload)
-    .map(([key, value]) => {
-      const v = String(value).replace(/\n/g, "<br/>");
-      return `<tr><td><strong>${key}:</strong></td><td>${v}</td></tr>`;
-    })
-    .join("")}</table>`;
 }
 
 const confirmationLocales = {

--- a/src/vercel/utils/htmlTable.ts
+++ b/src/vercel/utils/htmlTable.ts
@@ -1,0 +1,31 @@
+export type Payload = Record<string, string>;
+
+export function escapeHtml(str: string) {
+  return str.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return char;
+    }
+  });
+}
+
+export function buildHtmlTable(payload: Payload) {
+  return `<table>${Object.entries(payload)
+    .map(([key, value]) => {
+      const k = escapeHtml(key);
+      const v = escapeHtml(String(value)).replace(/\n/g, "<br/>");
+      return `<tr><td><strong>${k}:</strong></td><td>${v}</td></tr>`;
+    })
+    .join("")}</table>`;
+}
+


### PR DESCRIPTION
## Summary
- sanitize payload keys and values to prevent HTML injection in email tables
- factor out `buildHtmlTable` helper and add unit tests for escaping

## Testing
- `node --test dist-test/emailService.test.js`
- `npm run lint` *(fails: Unexpected any, react-refresh/only-export-components)*

------
https://chatgpt.com/codex/tasks/task_e_68933bc0ee148323845b0f78c85ecd84