### PR TITLE
Move Vercel serverless functions to api folder

### DIFF
--- a/api/consultation.ts
+++ b/api/consultation.ts
@@ -1,10 +1,11 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { PrismaClient } from "@prisma/client";
-import { sendConsultationEmail } from "../../../vercel/utils/emailService";
+import { sendConsultationEmail } from "../src/vercel/utils/emailService";
 
-const prisma = (globalThis as any).prisma ?? new PrismaClient();
-if (!(globalThis as any).prisma) {
-  (globalThis as any).prisma = prisma;
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+const prisma = globalForPrisma.prisma ?? new PrismaClient();
+if (!globalForPrisma.prisma) {
+  globalForPrisma.prisma = prisma;
 }
 
 interface ConsultationFormData {

--- a/api/contact.ts
+++ b/api/contact.ts
@@ -1,7 +1,7 @@
 // /api/contact.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { PrismaClient } from "@prisma/client";
-import { sendContactEmail } from "../../../vercel/utils/emailService";
+import { sendContactEmail } from "../src/vercel/utils/emailService";
 
 const prisma = new PrismaClient();
 

--- a/api/service-inquiry.ts
+++ b/api/service-inquiry.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { PrismaClient } from "@prisma/client";
-import { sendServiceInquiryEmail } from "../../../vercel/utils/emailService";
+import { sendServiceInquiryEmail } from "../src/vercel/utils/emailService";
 
 interface InquiryFormData {
   fullName: string;
@@ -23,9 +23,10 @@ interface InquiryFormData {
   newsletter: boolean;
 }
 
-const prisma = (globalThis as any).prisma ?? new PrismaClient();
-if (!(globalThis as any).prisma) {
-  (globalThis as any).prisma = prisma;
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+const prisma = globalForPrisma.prisma ?? new PrismaClient();
+if (!globalForPrisma.prisma) {
+  globalForPrisma.prisma = prisma;
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {


### PR DESCRIPTION
## Summary
- relocate contact, service inquiry, and consultation handlers to top-level `api/`
- fix prisma globals to avoid `any` usage

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: existing lint errors)
- `npx eslint api/contact.ts api/service-inquiry.ts api/consultation.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893476ac06c8323bdadd86e84376835