### PR TITLE
Expand database schemas for extended form fields

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,21 +21,44 @@
  }
 
  // Model for consultation requests
- model consultationRequest {
-  id        Int      @id @default(autoincrement())
-  name      String
-  email     String
-  phone     String?
-  message   String?
-  createdAt DateTime @default(now())
- }
+model consultationRequest {
+  id                 Int      @id @default(autoincrement())
+  fullName           String
+  email              String
+  phone              String?
+  company            String?
+  website            String?
+  businessType       String?
+  currentChallenges  String?
+  goals              String?
+  interestedServices Json?
+  preferredContact   String?
+  preferredTime      String?
+  additionalInfo     String?
+  newsletter         Boolean  @default(false)
+  createdAt          DateTime @default(now())
+}
 
- // Model for service inquiries
- model serviceInquiry {
-  id        Int      @id @default(autoincrement())
-  name      String
-  email     String
-  service   String?
-  message   String?
-  createdAt DateTime @default(now())
- }
+// Model for service inquiries
+model serviceInquiry {
+  id                Int      @id @default(autoincrement())
+  fullName          String
+  email             String
+  phone             String?
+  company           String?
+  website           String?
+  selectedService   String?
+  selectedPackage   String?
+  projectTypes      Json?
+  currentSituation  String?
+  projectGoals      String?
+  targetAudience    String?
+  timeline          String?
+  budget            String?
+  additionalServices Json?
+  preferredContact  String?
+  additionalInfo    String?
+  howDidYouHear     String?
+  newsletter        Boolean  @default(false)
+  createdAt         DateTime @default(now())
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },


### PR DESCRIPTION
## Summary
- extend consultation request model to capture detailed business info and preferences
- expand service inquiry model to store selected packages, audience details, and more
- allow JSON imports and default module interop for serverless functions

## Testing
- `npm run build`
- `npx tsc api/consultation.ts --noEmit --resolveJsonModule --esModuleInterop`
- `npx tsc api/service-inquiry.ts --noEmit --resolveJsonModule --esModuleInterop`
- `npm run lint` *(fails: Fast refresh and no-explicit-any errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68934a697b048323801cd32789a26e78