### PR TITLE
fix: remove redundant forceMount from select portal

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -62,7 +62,7 @@ const SelectContent = React.forwardRef<
     container?: HTMLElement | null;
   }
 >(({ className, children, position = "popper", forceMount, container, ...props }, ref) => (
-  <SelectPrimitive.Portal forceMount={forceMount} container={container}>
+  <SelectPrimitive.Portal container={container}>
     <SelectPrimitive.Content
       ref={ref}
       forceMount={forceMount}


### PR DESCRIPTION
## Summary
- remove forceMount prop from SelectPrimitive.Portal to avoid unnecessary mounting

## Testing
- `npm run lint` *(fails: Unexpected any and react-refresh errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6894af22dcc88323851cff88dbf6b8d9