### PR TITLE
refactor: remove forceMount prop from SelectContent

### DIFF
--- a/src/components/FreeConsultationPage.tsx
+++ b/src/components/FreeConsultationPage.tsx
@@ -362,7 +362,7 @@ export function FreeConsultationPage() {
                     <SelectTrigger className={`border-gray-300 focus:border-bdigital-cyan ${errors.businessType ? "border-red-500" : ""}`}>
                       <SelectValue placeholder={t("form.placeholder_business_type")} />
                     </SelectTrigger>
-                    <SelectContent forceMount>
+                    <SelectContent>
                       <SelectItem value="startup">Startup</SelectItem>
                       <SelectItem value="small-business">Malo preduzeće</SelectItem>
                       <SelectItem value="medium-business">Srednje preduzeće</SelectItem>
@@ -487,7 +487,7 @@ export function FreeConsultationPage() {
                     <SelectTrigger className="border-gray-300 focus:border-bdigital-cyan">
                       <SelectValue placeholder={t("form.placeholder_preferred_time")} />
                     </SelectTrigger>
-                    <SelectContent forceMount>
+                    <SelectContent>
                       <SelectItem value="morning">Ujutru (09:00-12:00)</SelectItem>
                       <SelectItem value="afternoon">Popodne (12:00-16:00)</SelectItem>
                       <SelectItem value="evening">Uveče (16:00-19:00)</SelectItem>

--- a/src/components/serviceInquirySteps/Step3.tsx
+++ b/src/components/serviceInquirySteps/Step3.tsx
@@ -34,7 +34,7 @@ export function Step3({ formData, errors, touched, updateFormData, handleAdditio
               >
                 <SelectValue placeholder={t("form.placeholder_timeline")} />
               </SelectTrigger>
-              <SelectContent forceMount className="z-[999] bg-white text-black shadow-lg rounded border border-gray-200">
+              <SelectContent className="z-[999] bg-white text-black shadow-lg rounded border border-gray-200">
                 <SelectItem value="asap">{t("form.timeline_option.asap")}</SelectItem>
                 <SelectItem value="1-month">{t("form.timeline_option.one_month")}</SelectItem>
                 <SelectItem value="2-3-months">{t("form.timeline_option.two_three_months")}</SelectItem>
@@ -61,7 +61,7 @@ export function Step3({ formData, errors, touched, updateFormData, handleAdditio
               >
                 <SelectValue placeholder={t("form.placeholder_budget")} />
               </SelectTrigger>
-              <SelectContent forceMount className="z-[999] bg-white text-black shadow-lg rounded border border-gray-200">
+              <SelectContent className="z-[999] bg-white text-black shadow-lg rounded border border-gray-200">
                 <SelectItem value="under-1000">{t("form.budget_option.under_1000")}</SelectItem>
                 <SelectItem value="1000-2500">{t("form.budget_option.1000_2500")}</SelectItem>
                 <SelectItem value="2500-5000">{t("form.budget_option.2500_5000")}</SelectItem>

--- a/src/components/serviceInquirySteps/Step4.tsx
+++ b/src/components/serviceInquirySteps/Step4.tsx
@@ -58,7 +58,7 @@ export function Step4({ formData, errors, touched, updateFormData, handleBlur }:
           <SelectTrigger className="border-gray-300 focus:border-bdigital-cyan">
             <SelectValue placeholder={t("form.placeholder_how_hear")} />
           </SelectTrigger>
-          <SelectContent forceMount className="z-[999] bg-white text-black shadow-lg rounded border border-gray-200">
+          <SelectContent className="z-[999] bg-white text-black shadow-lg rounded border border-gray-200">
             <SelectItem value="google">{t("form.how_hear_option.google")}</SelectItem>
             <SelectItem value="social-media">{t("form.how_hear_option.social_media")}</SelectItem>
             <SelectItem value="referral">{t("form.how_hear_option.referral")}</SelectItem>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -58,14 +58,12 @@ SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayNam
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
-    forceMount?: boolean;
     container?: HTMLElement | null;
   }
->(({ className, children, position = "popper", forceMount, container, ...props }, ref) => (
+>(({ className, children, position = "popper", container, ...props }, ref) => (
   <SelectPrimitive.Portal container={container}>
     <SelectPrimitive.Content
       ref={ref}
-      forceMount={forceMount}
       className={cn(
         "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
         position === "popper" &&


### PR DESCRIPTION
## Summary
- remove obsolete `forceMount` prop from `SelectContent`
- update `SelectContent` usages across forms to rely on default mounting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react-refresh and eslint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894b0f347fc8323bee60824ea4761d0