### PR TITLE
feat: add useActiveSection hook

### DIFF
--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Hook that returns the ID of the currently active section based on its
+ * visibility in the viewport.
+ *
+ * @param sectionIds - Array of section element IDs to observe.
+ * @param offset - Optional offset in pixels to adjust the intersection point.
+ */
+export function useActiveSection(sectionIds: string[], offset: number = 0) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        });
+      },
+      {
+        rootMargin: `-${offset}px 0px`,
+        threshold: 0.25,
+      }
+    );
+
+    sectionIds.forEach((id) => {
+      const element = document.getElementById(id);
+      if (element) {
+        observer.observe(element);
+      }
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [sectionIds, offset]);
+
+  return activeId;
+}


### PR DESCRIPTION
## Summary
- add useActiveSection hook for tracking current viewport section

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_689f00b6f03083239d2f4896f809cdd1