### PR TITLE
feat: add scroll direction hook

### DIFF
--- a/src/hooks/useScrollDir.ts
+++ b/src/hooks/useScrollDir.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Hook that returns the current scroll direction ("up" or "down").
+ * The direction is updated inside a requestAnimationFrame callback and
+ * the scroll listener is attached with passive mode.
+ */
+export function useScrollDir() {
+  const [scrollDir, setScrollDir] = useState<"up" | "down">("down");
+  const lastScrollY = useRef(0);
+  const latestScrollY = useRef(0);
+  const ticking = useRef(false);
+
+  useEffect(() => {
+    lastScrollY.current = window.scrollY;
+    latestScrollY.current = window.scrollY;
+
+    const update = () => {
+      const scrollY = latestScrollY.current;
+      if (scrollY > lastScrollY.current) {
+        setScrollDir("down");
+      } else if (scrollY < lastScrollY.current) {
+        setScrollDir("up");
+      }
+      lastScrollY.current = scrollY;
+      ticking.current = false;
+    };
+
+    const onScroll = () => {
+      latestScrollY.current = window.scrollY;
+      if (!ticking.current) {
+        requestAnimationFrame(update);
+        ticking.current = true;
+      }
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, []);
+
+  return scrollDir;
+}
+


### PR DESCRIPTION
## Summary
- add `useScrollDir` hook to track scroll direction via `requestAnimationFrame`

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_689f01bca09c8323b09cff7a681352b8