### PR TITLE
feat: add mobile quick navigation styles

### DIFF
--- a/src/styles/mobile-quick-nav.css
+++ b/src/styles/mobile-quick-nav.css
@@ -1,0 +1,21 @@
+/* Styles for the mobile quick navigation */
+
+.mqn-backdrop {
+  background-color: rgba(255, 255, 255, 0.8);
+}
+
+@supports ((-webkit-backdrop-filter: none) or (backdrop-filter: none)) {
+  .mqn-backdrop {
+    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(8px);
+    background-color: transparent;
+  }
+}
+
+[data-anchor] {
+  scroll-margin-top: 5rem;
+}
+
+.mqn-layer {
+  transform: translateZ(0);
+}


### PR DESCRIPTION
## Summary
- add mobile quick navigation stylesheet
- provide backdrop blur with fallback, anchor scroll offset and translateZ layer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package 'globals' imported in eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_689f0b32313483239ff27c17eea76829