### PR TITLE
Guard browser APIs for SSR compatibility

### DIFF
--- a/src/components/LanguageContext.tsx
+++ b/src/components/LanguageContext.tsx
@@ -11,11 +11,19 @@ interface LanguageContextType {
 
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
 
+interface LanguageProviderProps {
+  children: ReactNode;
+  initialLanguage?: Language;
+}
 
-export function LanguageProvider({ children }: { children: ReactNode }) {
-  const [language, setLanguage] = useState<Language>(
-    (localStorage.getItem('language') as Language) || 'me'
-  );
+export function LanguageProvider({ children, initialLanguage }: LanguageProviderProps) {
+  const [language, setLanguage] = useState<Language>(() => {
+    if (typeof window === 'undefined') {
+      return initialLanguage ?? 'me';
+    }
+    const storedLanguage = window.localStorage.getItem('language') as Language | null;
+    return storedLanguage ?? initialLanguage ?? 'me';
+  });
   const [translations, setTranslations] = useState<Record<string, string>>({});
 
   useEffect(() => {
@@ -25,7 +33,10 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   }, [language]);
 
   useEffect(() => {
-    localStorage.setItem('language', language);
+    if (typeof window === 'undefined') {
+      return;
+    }
+    window.localStorage.setItem('language', language);
   }, [language]);
 
   const t = (key: string): string => {

--- a/src/components/ui/use-mobile.ts
+++ b/src/components/ui/use-mobile.ts
@@ -8,6 +8,10 @@ export function useIsMobile() {
   );
 
   React.useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -11,6 +11,14 @@ export function useActiveSection(sectionIds: string[], offset: number = 0) {
   const [activeId, setActiveId] = useState<string | null>(null);
 
   useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    if (typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -13,6 +13,10 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(active = true)
 
   useEffect(() => {
     const container = containerRef.current;
+    if (typeof document === "undefined") {
+      return;
+    }
+
     if (!active || !container) {
       return;
     }

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -9,6 +9,10 @@ export function usePrefersReducedMotion() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
 
   useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
     const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
 
     const handleChange = (event: MediaQueryListEvent) => {

--- a/src/hooks/useScrollDir.ts
+++ b/src/hooks/useScrollDir.ts
@@ -12,6 +12,10 @@ export function useScrollDir() {
   const ticking = useRef(false);
 
   useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
     lastScrollY.current = window.scrollY;
     latestScrollY.current = window.scrollY;
 


### PR DESCRIPTION
## Summary
- defer router initialization until after mount and guard URL/history usage when the window object is unavailable
- allow the language and inquiry providers to read browser state only in the client and accept server-provided defaults
- harden UI hooks against SSR by checking for window/document and providing safe localStorage helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbb421d064832386ba5b47f3915c60