### PR TITLE
Refactor router service page detection

### DIFF
--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -5,6 +5,7 @@ import {
   buildPath,
   defaultLocale,
   parsePathname,
+  servicePageIds,
   type Locale,
   type PageType,
 } from "../routing";
@@ -18,6 +19,27 @@ interface NavigateOptions {
 
 export { servicePageIds, type PageType } from "../routing";
 export type { Locale } from "../routing";
+
+export function getPageFromPath(path: string): PageType {
+  const cleanPath = path.replace(/^\/+|\/+$/g, "");
+
+  if (cleanPath.length === 0 || cleanPath === "home") {
+    return "home";
+  }
+
+  const servicePageId = cleanPath as (typeof servicePageIds)[number];
+  if (servicePageIds.includes(servicePageId)) {
+    return servicePageId;
+  }
+
+  switch (cleanPath) {
+    case "service-inquiry":
+    case "free-consultation":
+      return cleanPath;
+    default:
+      return "home";
+  }
+}
 
 export function useRouter() {
   const location = useLocation();


### PR DESCRIPTION
## Summary
- update getPageFromPath to reuse servicePageIds for service route detection instead of hard-coded cases
- ensure unknown routes continue to fall back to the home page when mapping paths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbb8b82a488323b386a3b268313035