### PR TITLE
feat: sync html lang with locale

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="<!--app-lang-->">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="./public/favicon.ico" />

--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -39,6 +39,7 @@ function collectRoutes() {
 function injectRenderedApp(template: string, rendered: RenderResult) {
   const stateScript = serializeState(rendered.initialState);
   return template
+    .replace("<!--app-lang-->", rendered.htmlLang)
     .replace("<!--app-head-->", `${rendered.head}${rendered.preloadLinks}`)
     .replace("<!--app-html-->", rendered.html)
     .replace("<!--app-state-->", stateScript);

--- a/server.ts
+++ b/server.ts
@@ -68,6 +68,7 @@ async function handleRequest({
 function injectRenderedApp(template: string, rendered: RenderResult) {
   const stateScript = serializeState(rendered.initialState);
   return template
+    .replace("<!--app-lang-->", rendered.htmlLang)
     .replace("<!--app-head-->", `${rendered.head}${rendered.preloadLinks}`)
     .replace("<!--app-html-->", rendered.html)
     .replace("<!--app-state-->", stateScript);

--- a/src/components/LanguageContext.tsx
+++ b/src/components/LanguageContext.tsx
@@ -67,6 +67,12 @@ export function LanguageProvider({
     }
   }, [language]);
 
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      document.documentElement.lang = language;
+    }
+  }, [language]);
+
   const translations = useMemo(() => TRANSLATIONS[language], [language]);
 
   const setLanguage = (lang: Language) => {

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -19,6 +19,7 @@ export interface RenderResult {
   html: string;
   head: string;
   preloadLinks: string;
+  htmlLang: string;
   initialState: {
     locale: string;
   };
@@ -71,6 +72,7 @@ export function render(url: string, options: RenderOptions = {}): RenderResult {
     html,
     head,
     preloadLinks,
+    htmlLang: locale,
     initialState: { locale },
   };
 }


### PR DESCRIPTION
## Summary
- return the resolved locale from the SSR renderer and inject it into the HTML template
- update server and prerender template injection to replace the html lang placeholder
- synchronize the document <html lang> attribute on the client when language changes

## Testing
- npm run build *(fails: missing type definition packages due to unavailable npm registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68dbcc69f6908323a94f43e0681ac0a1