### PR TITLE
Add localized SEO metadata for pages

### DIFF
--- a/src/config/seo-meta.ts
+++ b/src/config/seo-meta.ts
@@ -1,0 +1,115 @@
+import { defaultLocale, type Locale, type PageType } from "../routing";
+
+export interface SeoMetadata {
+  title: string;
+  description: string;
+}
+
+const DEFAULT_SEO_METADATA: SeoMetadata = {
+  title: "BDigital Agency",
+  description:
+    "BDigital is a full-service digital agency delivering design, marketing, and growth solutions.",
+};
+
+const SEO_METADATA: Record<Locale, Partial<Record<PageType, SeoMetadata>>> = {
+  me: {
+    home: {
+      title: "BDigital agencija | Digitalni marketing i web dizajn",
+      description:
+        "BDigital je full-service digitalna agencija iz Crne Gore koja isporučuje dizajn, marketing i strategije rasta.",
+    },
+    "web-design": {
+      title: "Web dizajn i development | BDigital agencija",
+      description:
+        "Pravimo moderne, responzivne sajtove optimizovane za konverzije i rast vašeg biznisa.",
+    },
+    seo: {
+      title: "SEO usluge u Crnoj Gori | BDigital agencija",
+      description:
+        "Povećajte vidljivost na pretraživačima i osvojite više klijenata uz naš SEO tim.",
+    },
+    "social-media": {
+      title: "Upravljanje društvenim mrežama | BDigital agencija",
+      description:
+        "Gradimo vašu zajednicu i povećavamo angažman kroz kreativne kampanje na društvenim mrežama.",
+    },
+    branding: {
+      title: "Brending i grafički dizajn | BDigital agencija",
+      description:
+        "Razvijamo prepoznatljiv vizuelni identitet i profesionalne marketinške materijale za vaš brend.",
+    },
+    strategy: {
+      title: "Digitalna strategija i konsalting | BDigital agencija",
+      description:
+        "Planovi zasnovani na podacima koji ubrzavaju rast i prodaju vašeg poslovanja.",
+    },
+    "service-inquiry": {
+      title: "Zatražite ponudu | BDigital agencija",
+      description:
+        "Pošaljite detalje projekta i dobićete personalizovanu ponudu u roku od 24 sata.",
+    },
+    "free-consultation": {
+      title: "Besplatne konsultacije | BDigital agencija",
+      description:
+        "Rezervišite besplatan razgovor sa našim timom digitalnog marketinga i saznajte kako možemo pomoći.",
+    },
+  },
+  en: {
+    home: {
+      title: "BDigital Agency | Digital Marketing & Web Design in Montenegro",
+      description:
+        "BDigital is a full-service digital agency delivering design, marketing, and growth solutions across Montenegro.",
+    },
+    "web-design": {
+      title: "Web Design & Development | BDigital Agency",
+      description:
+        "We craft modern, responsive websites that are optimized for conversions and business growth.",
+    },
+    seo: {
+      title: "SEO Services in Montenegro | BDigital Agency",
+      description:
+        "Increase your search visibility and win more clients with our comprehensive SEO services.",
+    },
+    "social-media": {
+      title: "Social Media Marketing Services | BDigital Agency",
+      description:
+        "Grow your brand community and engagement with data-driven social media strategies.",
+    },
+    branding: {
+      title: "Branding & Graphic Design | BDigital Agency",
+      description:
+        "Build a memorable visual identity with bespoke branding and design solutions from our creative team.",
+    },
+    strategy: {
+      title: "Digital Strategy & Consulting | BDigital Agency",
+      description:
+        "Develop a data-driven digital strategy that accelerates growth and delivers measurable results.",
+    },
+    "service-inquiry": {
+      title: "Request a Project Quote | BDigital Agency",
+      description:
+        "Tell us about your project and receive a tailored proposal from the BDigital team within 24 hours.",
+    },
+    "free-consultation": {
+      title: "Book a Free Consultation | BDigital Agency",
+      description:
+        "Schedule a free consultation with our digital experts to discover growth opportunities for your business.",
+    },
+  },
+};
+
+export function getSeoMetadata(locale: Locale, page: PageType): SeoMetadata {
+  const localized = SEO_METADATA[locale]?.[page];
+  if (localized) {
+    return localized;
+  }
+
+  const fallback = SEO_METADATA[defaultLocale]?.[page];
+  if (fallback) {
+    return fallback;
+  }
+
+  return DEFAULT_SEO_METADATA;
+}
+
+export { DEFAULT_SEO_METADATA, SEO_METADATA };

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -3,6 +3,7 @@ import { renderToString } from "react-dom/server";
 import { StaticRouter } from "react-router-dom/server";
 import { AppRoutes } from "./routes";
 import { SITE_BASE_URL } from "./config/site";
+import { getSeoMetadata } from "./config/seo-meta";
 import { parsePathname } from "./routing";
 import { buildCanonicalCluster } from "./utils/seo";
 
@@ -29,10 +30,6 @@ export interface RenderOptions {
   manifest?: Manifest;
 }
 
-const TITLE = "BDigital Agency";
-const DESCRIPTION =
-  "BDigital is a full-service digital agency delivering design, marketing, and growth solutions.";
-
 export function render(url: string, options: RenderOptions = {}): RenderResult {
   const app = (
     <StrictMode>
@@ -52,9 +49,11 @@ export function render(url: string, options: RenderOptions = {}): RenderResult {
     siteBaseUrl: SITE_BASE_URL,
   });
 
+  const metadata = getSeoMetadata(locale, page);
+
   const headParts = [
-    `<title>${TITLE}</title>`,
-    `<meta name="description" content="${DESCRIPTION}" />`,
+    `<title>${escapeHtml(metadata.title)}</title>`,
+    `<meta name="description" content="${escapeAttribute(metadata.description)}" />`,
     `<link rel="canonical" href="${escapeAttribute(canonicalCluster.canonical)}">`,
     ...canonicalCluster.alternates.map(
       (alternate) =>
@@ -121,4 +120,8 @@ function renderPreloadLinks(manifest: Manifest, entry: string) {
 
 function escapeAttribute(value: string): string {
   return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,6 @@
-import type { ReactElement } from "react";
+import { useEffect, type ReactElement } from "react";
 import { Navigate, Outlet, useLocation, useParams, useRoutes, type RouteObject } from "react-router-dom";
-import { LanguageProvider } from "./components/LanguageContext";
+import { LanguageProvider, useLanguage } from "./components/LanguageContext";
 import { Navigation } from "./components/Navigation";
 import { HeroSection } from "./components/HeroSection";
 import { ServicesSection } from "./components/ServicesSection";
@@ -17,6 +17,7 @@ import { StrategyPage } from "./components/services/StrategyPage";
 import { ServiceInquiryForm } from "./components/ServiceInquiryForm";
 import { FreeConsultationPage } from "./components/FreeConsultationPage";
 import { MobileQuickNav } from "./components/MobileQuickNav";
+import { getSeoMetadata } from "./config/seo-meta";
 import {
   buildLocalizedPath,
   defaultLocale,
@@ -26,6 +27,33 @@ import {
   type PageType,
 } from "./routing";
 import "./styles/mobile-quick-nav.css";
+
+function SeoMetadataUpdater() {
+  const location = useLocation();
+  const { language } = useLanguage();
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    const parsed = parsePathname(location.pathname);
+    const locale = parsed.locale ?? language ?? defaultLocale;
+    const { title, description } = getSeoMetadata(locale, parsed.page);
+
+    document.title = title;
+
+    let descriptionTag = document.querySelector('meta[name="description"]');
+    if (!descriptionTag) {
+      descriptionTag = document.createElement("meta");
+      descriptionTag.setAttribute("name", "description");
+      document.head.appendChild(descriptionTag);
+    }
+    descriptionTag.setAttribute("content", description);
+  }, [language, location.pathname]);
+
+  return null;
+}
 
 function HomePage() {
   return (
@@ -77,6 +105,7 @@ function LocalizedLayout() {
 
   return (
     <LanguageProvider initialLanguage={initialLanguage} localeFromRoute={routeLocale}>
+      <SeoMetadataUpdater />
       <AppLayout />
     </LanguageProvider>
   );


### PR DESCRIPTION
## Summary
- create a shared SEO metadata map that provides localized titles and descriptions for every page
- update the server render pipeline to pull localized metadata with sensible fallbacks
- sync the document title and description on client-side navigation using the shared metadata map

## Testing
- npm run build *(fails: missing workspace dependencies such as react and related type packages)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd6556e748323a193b6935374ff3f