### PR TITLE
Add localized social meta tags for SSR output

### DIFF
--- a/public/social-share-en.svg
+++ b/public/social-share-en.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0ea5e9" />
+      <stop offset="1" stop-color="#3b82f6" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" rx="32" />
+  <text x="80" y="210" fill="#f8fafc" font-family="'Inter', 'Segoe UI', sans-serif" font-size="72" font-weight="700">
+    BDigital Agency
+  </text>
+  <text x="80" y="310" fill="#e2e8f0" font-family="'Inter', 'Segoe UI', sans-serif" font-size="42">
+    Digital marketing that works
+  </text>
+  <text x="80" y="410" fill="#0f172a" font-family="'Inter', 'Segoe UI', sans-serif" font-size="30" font-weight="600" opacity="0.85">
+    Tailored growth &amp; web experiences for Montenegro
+  </text>
+</svg>

--- a/public/social-share-me.svg
+++ b/public/social-share-me.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f97316" />
+      <stop offset="1" stop-color="#ef4444" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" rx="32" />
+  <text x="80" y="210" fill="#fff7ed" font-family="'Inter', 'Segoe UI', sans-serif" font-size="72" font-weight="700">
+    BDigital agencija
+  </text>
+  <text x="80" y="310" fill="#ffedd5" font-family="'Inter', 'Segoe UI', sans-serif" font-size="42">
+    Digitalni marketing koji radi
+  </text>
+  <text x="80" y="410" fill="#7c2d12" font-family="'Inter', 'Segoe UI', sans-serif" font-size="30" font-weight="600" opacity="0.85">
+    Rješenja za rast biznisa u Crnoj Gori
+  </text>
+</svg>

--- a/src/config/seo-meta.ts
+++ b/src/config/seo-meta.ts
@@ -1,14 +1,22 @@
 import { defaultLocale, type Locale, type PageType } from "../routing";
+import { SITE_BASE_URL } from "./site";
 
 export interface SeoMetadata {
   title: string;
   description: string;
+  images?: string[];
 }
+
+const SOCIAL_IMAGE_BY_LOCALE: Record<Locale, string[]> = {
+  me: [`${SITE_BASE_URL}/social-share-me.svg`],
+  en: [`${SITE_BASE_URL}/social-share-en.svg`],
+};
 
 const DEFAULT_SEO_METADATA: SeoMetadata = {
   title: "BDigital Agency",
   description:
     "BDigital is a full-service digital agency delivering design, marketing, and growth solutions.",
+  images: SOCIAL_IMAGE_BY_LOCALE[defaultLocale],
 };
 
 const SEO_METADATA: Record<Locale, Partial<Record<PageType, SeoMetadata>>> = {
@@ -101,15 +109,23 @@ const SEO_METADATA: Record<Locale, Partial<Record<PageType, SeoMetadata>>> = {
 export function getSeoMetadata(locale: Locale, page: PageType): SeoMetadata {
   const localized = SEO_METADATA[locale]?.[page];
   if (localized) {
-    return localized;
+    return withSeoDefaults(locale, localized);
   }
 
   const fallback = SEO_METADATA[defaultLocale]?.[page];
   if (fallback) {
-    return fallback;
+    return withSeoDefaults(locale, fallback);
   }
 
-  return DEFAULT_SEO_METADATA;
+  return withSeoDefaults(locale, DEFAULT_SEO_METADATA);
+}
+
+function withSeoDefaults(locale: Locale, metadata: SeoMetadata): SeoMetadata {
+  const localeImages = SOCIAL_IMAGE_BY_LOCALE[locale] ?? SOCIAL_IMAGE_BY_LOCALE[defaultLocale] ?? [];
+  return {
+    ...metadata,
+    images: metadata.images ?? localeImages,
+  };
 }
 
 export { DEFAULT_SEO_METADATA, SEO_METADATA };

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -4,7 +4,7 @@ import { StaticRouter } from "react-router-dom/server";
 import { AppRoutes } from "./routes";
 import { SITE_BASE_URL } from "./config/site";
 import { getSeoMetadata } from "./config/seo-meta";
-import { parsePathname } from "./routing";
+import { locales, parsePathname } from "./routing";
 import { buildCanonicalCluster } from "./utils/seo";
 
 export interface ManifestEntry {
@@ -54,11 +54,27 @@ export function render(url: string, options: RenderOptions = {}): RenderResult {
   const headParts = [
     `<title>${escapeHtml(metadata.title)}</title>`,
     `<meta name="description" content="${escapeAttribute(metadata.description)}" />`,
+    `<meta property="og:title" content="${escapeAttribute(metadata.title)}">`,
+    `<meta property="og:description" content="${escapeAttribute(metadata.description)}">`,
+    `<meta name="twitter:title" content="${escapeAttribute(metadata.title)}">`,
+    `<meta name="twitter:description" content="${escapeAttribute(metadata.description)}">`,
+    `<meta property="og:locale" content="${escapeAttribute(locale)}">`,
+    ...locales
+      .filter((supportedLocale) => supportedLocale !== locale)
+      .map(
+        (alternateLocale) =>
+          `<meta property="og:locale:alternate" content="${escapeAttribute(alternateLocale)}">`,
+      ),
+    `<meta name="twitter:card" content="summary_large_image">`,
     `<link rel="canonical" href="${escapeAttribute(canonicalCluster.canonical)}">`,
     ...canonicalCluster.alternates.map(
       (alternate) =>
         `<link rel="alternate" hreflang="${alternate.hreflang}" href="${escapeAttribute(alternate.href)}">`,
     ),
+    ...(metadata.images ?? []).flatMap((imageUrl) => [
+      `<meta property="og:image" content="${escapeAttribute(imageUrl)}">`,
+      `<meta name="twitter:image" content="${escapeAttribute(imageUrl)}">`,
+    ]),
   ];
 
   const head = headParts.join("\n");


### PR DESCRIPTION
## Summary
- extend the SSR head assembly to emit Open Graph and Twitter title/description/locale meta tags that mirror the active locale and alternates
- provide default locale-specific social share image URLs through the SEO metadata helper and add matching SVG assets

## Testing
- npm run build *(fails: TypeScript cannot find several @types packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd8479dd08323ae59eb1ae4a0197a