### PR TITLE
Sanitize canonical URL generation

### DIFF
--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -22,7 +22,10 @@ export function buildCanonicalCluster({
   siteBaseUrl,
 }: BuildCanonicalClusterOptions): CanonicalCluster {
   const base = normalizeSiteBase(siteBaseUrl);
-  const canonical = currentUrl.href;
+  const canonicalUrl = new URL(currentUrl.href);
+  canonicalUrl.search = "";
+  canonicalUrl.hash = "";
+  const canonical = canonicalUrl.href;
 
   const alternates: AlternateHref[] = locales.map((locale) => ({
     hreflang: locale,


### PR DESCRIPTION
## Summary
- clone the current request URL when building canonical clusters so canonical links exclude search and hash data

## Testing
- npm run build *(fails: missing dependencies in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdd349c9883238783eadbbe235c38