### PR TITLE
Add SSR and client JSON-LD structured data updates

### DIFF
--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -5,7 +5,12 @@ import { AppRoutes } from "./routes";
 import { SITE_BASE_URL } from "./config/site";
 import { getSeoMetadata } from "./config/seo-meta";
 import { locales, parsePathname } from "./routing";
-import { buildCanonicalCluster } from "./utils/seo";
+import {
+  STRUCTURED_DATA_ELEMENT_ID,
+  buildCanonicalCluster,
+  buildWebPageJsonLd,
+  serializeJsonLd,
+} from "./utils/seo";
 
 export interface ManifestEntry {
   file: string;
@@ -51,6 +56,17 @@ export function render(url: string, options: RenderOptions = {}): RenderResult {
 
   const metadata = getSeoMetadata(locale, page);
 
+  const structuredData = buildWebPageJsonLd({
+    locale,
+    title: metadata.title,
+    description: metadata.description,
+    url: canonicalCluster.canonical,
+  });
+
+  const jsonLdScript = `<script id="${STRUCTURED_DATA_ELEMENT_ID}" type="application/ld+json">${serializeJsonLd(
+    structuredData,
+  )}</script>`;
+
   const headParts = [
     `<title>${escapeHtml(metadata.title)}</title>`,
     `<meta name="description" content="${escapeAttribute(metadata.description)}" />`,
@@ -75,6 +91,7 @@ export function render(url: string, options: RenderOptions = {}): RenderResult {
       `<meta property="og:image" content="${escapeAttribute(imageUrl)}">`,
       `<meta name="twitter:image" content="${escapeAttribute(imageUrl)}">`,
     ]),
+    jsonLdScript,
   ];
 
   const head = headParts.join("\n");

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -16,6 +16,15 @@ export interface BuildCanonicalClusterOptions {
   siteBaseUrl: string;
 }
 
+export interface WebPageJsonLdOptions {
+  locale: Locale;
+  title: string;
+  description: string;
+  url: string;
+}
+
+export const STRUCTURED_DATA_ELEMENT_ID = "seo-structured-data";
+
 export function buildCanonicalCluster({
   currentUrl,
   page,
@@ -42,6 +51,29 @@ export function buildCanonicalCluster({
     canonical,
     alternates: dedupeAlternates(alternates),
   };
+}
+
+export function buildWebPageJsonLd({
+  locale,
+  title,
+  description,
+  url,
+}: WebPageJsonLdOptions) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    inLanguage: locale,
+    name: title,
+    description,
+    url,
+  };
+}
+
+export function serializeJsonLd(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
 }
 
 function buildAbsoluteLocalizedHref(


### PR DESCRIPTION
## Summary
- add utilities to generate and serialize locale-aware WebPage JSON-LD metadata
- include the structured data script in the server-rendered head output
- keep the JSON-LD in sync during client-side navigation by updating SeoMetadataUpdater

## Testing
- npm run build *(fails: missing dependencies such as React and Radix packages in the TypeScript build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe08548f483239171c3f68a101ca0