### PR TITLE
Refine locale resolution for localized links

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,19 +1,15 @@
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Card, CardContent } from "./ui/card";
 import { Target, Eye, Heart, Users, Award, Clock } from "lucide-react";
 import { useLanguage } from "./LanguageContext";
 import { ImageWithFallback } from "./figma/ImageWithFallback";
-import { useRouteInfo } from "../hooks/useRouteInfo";
-import { buildLocalizedPath, defaultLocale, isLocale, type Locale, type PageType } from "../routing";
+import { useActiveLocale } from "../hooks/useActiveLocale";
+import { buildLocalizedPath, type PageType } from "../routing";
 
 export function AboutSection() {
   const { t } = useLanguage();
   const navigate = useNavigate();
-  const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale = (routeLocale ?? routeInfo.locale) as Locale;
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix } = useActiveLocale();
 
   const values = [
     {

--- a/src/components/FreeConsultationPage.tsx
+++ b/src/components/FreeConsultationPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "./ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Input } from "./ui/input";
@@ -27,8 +27,8 @@ import {
   TrendingUp,
 } from "lucide-react";
 import { useLanguage } from "./LanguageContext";
-import { useRouteInfo } from "../hooks/useRouteInfo";
-import { buildLocalizedPath, defaultLocale, isLocale, type Locale } from "../routing";
+import { useActiveLocale } from "../hooks/useActiveLocale";
+import { buildLocalizedPath } from "../routing";
 
 interface ConsultationFormData {
   fullName: string;
@@ -48,11 +48,7 @@ interface ConsultationFormData {
 
 export function FreeConsultationPage() {
   const navigate = useNavigate();
-  const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale: Locale = routeLocale ?? routeInfo.locale;
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix } = useActiveLocale();
   const { t, language } = useLanguage();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubmitted, setIsSubmitted] = useState(false);

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -2,19 +2,15 @@ import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
 import { ArrowRight, CheckCircle, Star, Users, Award } from "lucide-react";
 import { useLanguage } from "./LanguageContext";
-import { useNavigate, useParams } from "react-router-dom";
-import { buildLocalizedPath, defaultLocale, type Locale, isLocale } from "../routing";
-import { useRouteInfo } from "../hooks/useRouteInfo";
+import { useNavigate } from "react-router-dom";
+import { buildLocalizedPath } from "../routing";
+import { useActiveLocale } from "../hooks/useActiveLocale";
 import { ImageWithFallback } from "./figma/ImageWithFallback";
 
 export function HeroSection() {
   const { t: _t } = useLanguage();
   const navigate = useNavigate();
-  const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale: Locale = routeLocale ?? routeInfo.locale;
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix } = useActiveLocale();
 
   const stats = [
     { icon: Users, value: "100+", label: _t("hero.stats.clients") },

--- a/src/components/MobileQuickNav.tsx
+++ b/src/components/MobileQuickNav.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useMemo } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useLanguage } from "./LanguageContext";
 import { Menu, X, Home, Briefcase, FolderOpen, Users, MessageSquare, Phone, ArrowUp } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { smoothScroll } from "../utils/smoothScroll";
-import { buildLocalizedPath, defaultLocale, isLocale, type Locale } from "../routing";
-import { useRouteInfo } from "../hooks/useRouteInfo";
+import { buildLocalizedPath } from "../routing";
+import { useActiveLocale } from "../hooks/useActiveLocale";
 
 interface MobileQuickNavProps {
   onSectionClick?: (sectionId: string) => void;
@@ -37,11 +37,7 @@ export function MobileQuickNav({ onSectionClick }: MobileQuickNavProps) {
   const [showScrollTop, setShowScrollTop] = useState(false);
   const { language } = useLanguage();
   const navigate = useNavigate();
-  const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale: Locale = routeLocale ?? routeInfo.locale ?? (language as Locale);
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix } = useActiveLocale();
   const isMobile = useIsMobile();
 
   const translations: Record<

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,27 +1,18 @@
 import { useState, useEffect, useRef } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "./ui/button";
 import { Sheet, SheetContent, SheetTrigger, SheetHeader, SheetTitle, SheetDescription } from "./ui/sheet";
 import { Menu, X, ChevronDown } from "lucide-react";
 import { useLanguage } from "./LanguageContext";
-import {
-  buildLocalizedPath,
-  defaultLocale,
-  servicePageIds,
-  isLocale,
-  type Locale,
-  type PageType,
-} from "../routing";
+import { buildLocalizedPath, defaultLocale, servicePageIds, type Locale, type PageType } from "../routing";
 import { useRouteInfo } from "../hooks/useRouteInfo";
+import { useActiveLocale } from "../hooks/useActiveLocale";
 
 export function Navigation() {
   const { language, setLanguage, t: _t } = useLanguage();
   const navigate = useNavigate();
   const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale: Locale = routeLocale ?? routeInfo.locale ?? (language as Locale);
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix, routeLocale } = useActiveLocale();
   const [isOpen, setIsOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
   const [servicesOpen, setServicesOpen] = useState(false);

--- a/src/components/PortfolioSection.tsx
+++ b/src/components/PortfolioSection.tsx
@@ -1,13 +1,13 @@
 import { useState, useMemo } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import type { Project } from "../types";
 import { Button } from "./ui/button";
 import { Card, CardContent } from "./ui/card";
 import { Badge } from "./ui/badge";
 import { ExternalLink, Calendar, ChevronLeft, ChevronRight } from "lucide-react";
 import { useLanguage } from "./LanguageContext";
-import { useRouteInfo } from "../hooks/useRouteInfo";
-import { buildLocalizedPath, defaultLocale, isLocale, type Locale } from "../routing";
+import { useActiveLocale } from "../hooks/useActiveLocale";
+import { buildLocalizedPath } from "../routing";
 import { ImageWithFallback } from "./figma/ImageWithFallback";
 
 /** Allow projects to specify categories as a string (single or comma-separated) or string[] */
@@ -30,11 +30,7 @@ function normalizeCategories(input: unknown): string[] {
 export function PortfolioSection() {
   const { t: _t } = useLanguage();
   const navigate = useNavigate();
-  const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale: Locale = routeLocale ?? routeInfo.locale;
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix } = useActiveLocale();
   const [activeFilter, setActiveFilter] = useState("all");
   const [currentSlide, setCurrentSlide] = useState(0);
 

--- a/src/components/ServiceInquiryForm.tsx
+++ b/src/components/ServiceInquiryForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "./ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Badge } from "./ui/badge";
@@ -11,8 +11,8 @@ import { Step1 } from "./serviceInquirySteps/Step1";
 import { Step2 } from "./serviceInquirySteps/Step2";
 import { Step3 } from "./serviceInquirySteps/Step3";
 import { Step4 } from "./serviceInquirySteps/Step4";
-import { useRouteInfo } from "../hooks/useRouteInfo";
-import { buildLocalizedPath, defaultLocale, isLocale, type Locale } from "../routing";
+import { useActiveLocale } from "../hooks/useActiveLocale";
+import { buildLocalizedPath } from "../routing";
 
 export interface InquiryFormData {
   // Contact Information
@@ -49,11 +49,7 @@ export interface InquiryFormData {
 }
 export function ServiceInquiryForm() {
   const navigate = useNavigate();
-  const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale: Locale = routeLocale ?? routeInfo.locale;
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix } = useActiveLocale();
   const { t, language } = useLanguage();
   const [currentStep, setCurrentStep] = useState(1);
   const serviceInfo: Record<string, { title: string; description: string; icon: string }> = {

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { Button } from './ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
 import { Badge } from './ui/badge';
@@ -15,17 +15,13 @@ import {
   Award
 } from 'lucide-react';
 import { useLanguage } from './LanguageContext';
-import { useRouteInfo } from '../hooks/useRouteInfo';
-import { buildLocalizedPath, defaultLocale, isLocale, type PageType, type Locale } from '../routing';
+import { useActiveLocale } from '../hooks/useActiveLocale';
+import { buildLocalizedPath, type PageType } from '../routing';
 
 export function ServicesSection() {
   const { t } = useLanguage();
   const navigate = useNavigate();
-  const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale: Locale = routeLocale ?? routeInfo.locale;
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix } = useActiveLocale();
 
   const services = [
     {

--- a/src/components/services/BrandingPage.tsx
+++ b/src/components/services/BrandingPage.tsx
@@ -1,20 +1,16 @@
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "../ui/button";
 import { Card, CardContent } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Palette, FileImage, Type, Package, ArrowRight, CheckCircle } from "lucide-react";
 import { ImageWithFallback } from "../figma/ImageWithFallback";
 import { useLanguage } from "../LanguageContext";
-import { useRouteInfo } from "../../hooks/useRouteInfo";
-import { buildLocalizedPath, defaultLocale, isLocale, type Locale } from "../../routing";
+import { useActiveLocale } from "../../hooks/useActiveLocale";
+import { buildLocalizedPath } from "../../routing";
 
 export function BrandingPage() {
   const navigate = useNavigate();
-  const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale: Locale = routeLocale ?? routeInfo.locale;
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix } = useActiveLocale();
   const { t } = useLanguage();
 
   const services = [

--- a/src/components/services/SEOPage.tsx
+++ b/src/components/services/SEOPage.tsx
@@ -1,21 +1,17 @@
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Search, TrendingUp, BarChart3, MapPin, Smartphone, Globe, ArrowRight, CheckCircle, Star, Award } from "lucide-react";
 import { useLanguage } from "../LanguageContext";
 import { ImageWithFallback } from "../figma/ImageWithFallback";
-import { useRouteInfo } from "../../hooks/useRouteInfo";
-import { buildLocalizedPath, defaultLocale, isLocale, type Locale } from "../../routing";
+import { useActiveLocale } from "../../hooks/useActiveLocale";
+import { buildLocalizedPath } from "../../routing";
 
 export function SEOPage() {
   const { t } = useLanguage();
   const navigate = useNavigate();
-  const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale: Locale = routeLocale ?? routeInfo.locale;
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix } = useActiveLocale();
 
   const services = [
     {

--- a/src/components/services/SocialMediaPage.tsx
+++ b/src/components/services/SocialMediaPage.tsx
@@ -1,20 +1,16 @@
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "../ui/button";
 import { Card, CardContent } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Instagram, Facebook, TrendingUp, Camera, ArrowRight, CheckCircle } from "lucide-react";
 import { ImageWithFallback } from "../figma/ImageWithFallback";
 import { useLanguage } from "../LanguageContext";
-import { useRouteInfo } from "../../hooks/useRouteInfo";
-import { buildLocalizedPath, defaultLocale, isLocale, type Locale } from "../../routing";
+import { useActiveLocale } from "../../hooks/useActiveLocale";
+import { buildLocalizedPath } from "../../routing";
 
 export function SocialMediaPage() {
   const navigate = useNavigate();
-  const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale: Locale = routeLocale ?? routeInfo.locale;
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix } = useActiveLocale();
   const { t } = useLanguage();
 
   const services = [

--- a/src/components/services/StrategyPage.tsx
+++ b/src/components/services/StrategyPage.tsx
@@ -1,20 +1,16 @@
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "../ui/button";
 import { Card, CardContent } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { TrendingUp, Target, BarChart3, Users, ArrowRight, CheckCircle } from "lucide-react";
 import { ImageWithFallback } from "../figma/ImageWithFallback";
 import { useLanguage } from "../LanguageContext";
-import { useRouteInfo } from "../../hooks/useRouteInfo";
-import { buildLocalizedPath, defaultLocale, isLocale, type Locale } from "../../routing";
+import { useActiveLocale } from "../../hooks/useActiveLocale";
+import { buildLocalizedPath } from "../../routing";
 
 export function StrategyPage() {
   const navigate = useNavigate();
-  const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale: Locale = routeLocale ?? routeInfo.locale;
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix } = useActiveLocale();
   const { t } = useLanguage();
 
   const services = [

--- a/src/components/services/WebDesignPage.tsx
+++ b/src/components/services/WebDesignPage.tsx
@@ -1,21 +1,17 @@
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Button } from "../ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 import { Monitor, Zap, Search, ShoppingCart, Palette, Code, ArrowRight, CheckCircle, Clock } from "lucide-react";
 import { useLanguage } from "../LanguageContext";
 import { ImageWithFallback } from "../figma/ImageWithFallback";
-import { useRouteInfo } from "../../hooks/useRouteInfo";
-import { buildLocalizedPath, defaultLocale, isLocale, type Locale } from "../../routing";
+import { useActiveLocale } from "../../hooks/useActiveLocale";
+import { buildLocalizedPath } from "../../routing";
 
 export function WebDesignPage() {
   const { t } = useLanguage();
   const navigate = useNavigate();
-  const routeInfo = useRouteInfo();
-  const params = useParams<{ locale?: string }>();
-  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
-  const activeLocale: Locale = routeLocale ?? routeInfo.locale;
-  const includeLocalePrefix = routeLocale != null || activeLocale !== defaultLocale;
+  const { activeLocale, includeLocalePrefix } = useActiveLocale();
 
   const features = [
     {

--- a/src/hooks/useActiveLocale.ts
+++ b/src/hooks/useActiveLocale.ts
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+import { useParams } from "react-router-dom";
+import { useLanguage } from "../components/LanguageContext";
+import { defaultLocale, isLocale, type Locale } from "../routing";
+import { useRouteInfo } from "./useRouteInfo";
+
+interface ActiveLocaleInfo {
+  activeLocale: Locale;
+  includeLocalePrefix: boolean;
+  routeLocale?: Locale;
+}
+
+export function useActiveLocale(): ActiveLocaleInfo {
+  const { language } = useLanguage();
+  const routeInfo = useRouteInfo();
+  const params = useParams<{ locale?: string }>();
+
+  const routeLocale = isLocale(params.locale) ? params.locale : undefined;
+  const languageLocale = isLocale(language) ? language : undefined;
+
+  const { locale: parsedLocale, hasLocalePrefix } = routeInfo;
+
+  const activeLocale: Locale = useMemo(() => {
+    if (routeLocale) {
+      return routeLocale;
+    }
+
+    if (!hasLocalePrefix && languageLocale) {
+      return languageLocale;
+    }
+
+    return parsedLocale;
+  }, [hasLocalePrefix, languageLocale, parsedLocale, routeLocale]);
+
+  const includeLocalePrefix = useMemo(() => {
+    if (routeLocale) {
+      return true;
+    }
+
+    if (hasLocalePrefix) {
+      return true;
+    }
+
+    return activeLocale !== defaultLocale;
+  }, [activeLocale, hasLocalePrefix, routeLocale]);
+
+  return { activeLocale, includeLocalePrefix, routeLocale };
+}


### PR DESCRIPTION
## Summary
- add a useActiveLocale hook that reconciles URL params, parsed routing data, and the current language when selecting locales
- refactor navigation, home sections, forms, and service detail pages to build localized paths through the shared helper while preserving existing prefixes

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js/index.js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf46fc5b88323b20234c18adbf4d7