### PR TITLE
Normalize default-locale canonicals and add regression test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.test-dist
 *.local
 
 # Editor directories and files

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "ssr:serve": "NODE_ENV=production node dist/server/server.js",
     "ssg": "node dist/server/scripts/prerender.js",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "tsc -p tsconfig.tests.json && node --loader ./tests/esm-loader.mjs .test-dist/tests/seo-regression.test.js"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.11",

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -47,9 +47,11 @@ export function render(url: string, options: RenderOptions = {}): RenderResult {
   const html = renderToString(app);
 
   const requestUrl = new URL(url, SITE_BASE_URL);
-  const { locale, page } = parsePathname(requestUrl.pathname);
+  const { locale, page, hasLocalePrefix } = parsePathname(requestUrl.pathname);
   const canonicalCluster = buildCanonicalCluster({
     currentUrl: requestUrl,
+    hasLocalePrefix,
+    locale,
     page,
     siteBaseUrl: SITE_BASE_URL,
   });

--- a/tests/esm-loader.mjs
+++ b/tests/esm-loader.mjs
@@ -1,0 +1,21 @@
+import { access } from "node:fs/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier.startsWith("./") || specifier.startsWith("../")) {
+    const parts = specifier.split("/");
+    const lastPart = parts[parts.length - 1] ?? "";
+    if (!lastPart.includes(".")) {
+      const parentURL = context.parentURL ?? pathToFileURL(`${process.cwd()}/`).href;
+      const candidate = new URL(`${specifier}.js`, parentURL);
+      try {
+        await access(fileURLToPath(candidate));
+        return { url: candidate.href, shortCircuit: true };
+      } catch {
+        // Fall through to default resolver if the .js file is not found
+      }
+    }
+  }
+
+  return defaultResolve(specifier, context, defaultResolve);
+}

--- a/tests/seo-regression.test.ts
+++ b/tests/seo-regression.test.ts
@@ -1,0 +1,79 @@
+import { SITE_BASE_URL } from "../src/config/site";
+import { parsePathname } from "../src/routing";
+import { buildCanonicalCluster } from "../src/utils/seo";
+
+function assertCondition(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertEqual<T>(actual: T, expected: T, message: string): void {
+  if (actual !== expected) {
+    throw new Error(`${message}\nExpected: ${expected}\nReceived: ${actual}`);
+  }
+}
+
+const pathsToTest = ["/me/usluge/seo", "/usluge/seo"] as const;
+
+const results = pathsToTest.map((path) => {
+  const url = new URL(path, SITE_BASE_URL);
+  const parsed = parsePathname(url.pathname);
+  const cluster = buildCanonicalCluster({
+    currentUrl: url,
+    hasLocalePrefix: parsed.hasLocalePrefix,
+    locale: parsed.locale,
+    page: parsed.page,
+    siteBaseUrl: SITE_BASE_URL,
+  });
+
+  return { path, cluster };
+});
+
+const canonicalHrefs = new Set(results.map((result) => result.cluster.canonical));
+assertEqual(
+  canonicalHrefs.size,
+  1,
+  "Expected all canonical hrefs to normalize to the same Montenegrin URL",
+);
+
+const [normalizedCanonical] = canonicalHrefs;
+if (!normalizedCanonical) {
+  throw new Error("Failed to capture canonical href for comparison");
+}
+
+for (const { path, cluster } of results) {
+  assertEqual(
+    cluster.canonical,
+    normalizedCanonical,
+    `Canonical href for ${path} should match the normalized Montenegrin URL`,
+  );
+
+  const montenegrinAlternate = cluster.alternates.find(
+    (alternate) => alternate.hreflang === "me",
+  );
+  assertCondition(
+    montenegrinAlternate,
+    `Expected hreflang=\"me\" alternate for ${path} to be present`,
+  );
+  assertEqual(
+    montenegrinAlternate.href,
+    normalizedCanonical,
+    `hreflang=\"me\" alternate for ${path} should point to the canonical URL`,
+  );
+
+  const xDefaultAlternate = cluster.alternates.find(
+    (alternate) => alternate.hreflang === "x-default",
+  );
+  assertCondition(
+    xDefaultAlternate,
+    `Expected hreflang=\"x-default\" alternate for ${path} to be present`,
+  );
+  assertEqual(
+    xDefaultAlternate.href,
+    normalizedCanonical,
+    `hreflang=\"x-default\" alternate for ${path} should mirror the canonical URL`,
+  );
+}
+
+console.log("SEO canonical regression checks passed for", pathsToTest.join(", "));

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": [],
+    "outDir": ".test-dist",
+    "rootDir": ".",
+    "strict": false
+  },
+  "include": [
+    "src/config/site.ts",
+    "src/routing.ts",
+    "src/utils/seo.ts",
+    "tests/seo-regression.test.ts",
+    "src/locales/routes.json"
+  ]
+}


### PR DESCRIPTION
## Summary
- ensure the canonical cluster builder drops default-locale prefixes and keeps the active locale alternate aligned with the canonical URL
- update the SSR and client-side SEO paths to pass the locale prefix flag and rewrite canonical/hreflang tags accordingly during hydration
- add a lightweight TypeScript test configuration and loader plus a regression test that verifies the Montenegrin canonical and hreflang targets for /me/usluge/seo and /usluge/seo

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc49b078c883239d2debcf61c7d2d0