### PR TITLE
Add structured data builders and integrate schema graph

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">BDigital Logo</title>
+  <desc id="desc">Stylized letter B representing BDigital agency</desc>
+  <rect width="64" height="64" rx="12" fill="#00d4ff" />
+  <path
+    d="M20 16h15c7.18 0 13 5.82 13 13 0 4.43-2.22 8.35-5.62 10.72C45.2 41.2 47 44.81 47 49c0 5.52-4.48 10-10 10H20zM30 28a5 5 0 0 0 0 10h5c2.76 0 5-2.24 5-5s-2.24-5-5-5zm0-12a5 5 0 0 0 0 10h5c2.76 0 5-2.24 5-5s-2.24-5-5-5z"
+    fill="#0f172a"
+  />
+</svg>

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -8,6 +8,9 @@ import { locales, parsePathname } from "./routing";
 import {
   STRUCTURED_DATA_ELEMENT_ID,
   buildCanonicalCluster,
+  buildBreadcrumbListJsonLd,
+  buildOrganizationJsonLd,
+  buildWebsiteJsonLd,
   buildWebPageJsonLd,
   serializeJsonLd,
 } from "./utils/seo";
@@ -58,12 +61,30 @@ export function render(url: string, options: RenderOptions = {}): RenderResult {
 
   const metadata = getSeoMetadata(locale, page);
 
-  const structuredData = buildWebPageJsonLd({
-    locale,
-    title: metadata.title,
-    description: metadata.description,
-    url: canonicalCluster.canonical,
-  });
+  const structuredData = [
+    buildWebPageJsonLd({
+      locale,
+      title: metadata.title,
+      description: metadata.description,
+      url: canonicalCluster.canonical,
+    }),
+    buildOrganizationJsonLd({
+      locale,
+      siteBaseUrl: SITE_BASE_URL,
+      logoPath: "/logo.svg",
+    }),
+    buildWebsiteJsonLd({
+      locale,
+      siteBaseUrl: SITE_BASE_URL,
+    }),
+    buildBreadcrumbListJsonLd({
+      locale,
+      page,
+      siteBaseUrl: SITE_BASE_URL,
+      canonicalUrl: canonicalCluster.canonical,
+      pageTitle: metadata.title,
+    }),
+  ];
 
   const jsonLdScript = `<script id="${STRUCTURED_DATA_ELEMENT_ID}" type="application/ld+json">${serializeJsonLd(
     structuredData,

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -22,6 +22,9 @@ import { SITE_BASE_URL } from "./config/site";
 import {
   STRUCTURED_DATA_ELEMENT_ID,
   buildCanonicalCluster,
+  buildBreadcrumbListJsonLd,
+  buildOrganizationJsonLd,
+  buildWebsiteJsonLd,
   buildWebPageJsonLd,
   serializeJsonLd,
 } from "./utils/seo";
@@ -109,12 +112,30 @@ function SeoMetadataUpdater() {
       }
     }
 
-    const structuredData = buildWebPageJsonLd({
-      locale,
-      title,
-      description,
-      url: canonicalCluster?.canonical ?? canonicalUrl,
-    });
+    const structuredData = [
+      buildWebPageJsonLd({
+        locale,
+        title,
+        description,
+        url: canonicalUrl,
+      }),
+      buildOrganizationJsonLd({
+        locale,
+        siteBaseUrl: SITE_BASE_URL,
+        logoPath: "/logo.svg",
+      }),
+      buildWebsiteJsonLd({
+        locale,
+        siteBaseUrl: SITE_BASE_URL,
+      }),
+      buildBreadcrumbListJsonLd({
+        locale,
+        page: parsed.page,
+        siteBaseUrl: SITE_BASE_URL,
+        canonicalUrl,
+        pageTitle: title,
+      }),
+    ];
 
     let structuredDataTag = document.getElementById(
       STRUCTURED_DATA_ELEMENT_ID,


### PR DESCRIPTION
## Summary
- add reusable structured data builders for organization, website, and breadcrumb graph data used across SSR and the client router
- embed the combined schema graph during SSR and client-side navigation to keep structured data in sync with canonical URLs
- add a shared logo asset referenced by the organization schema

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68dc4f08ab7c8323ac5b3c789c1ad675