### PR TITLE
Fix undefined routeInfo references

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -4,12 +4,14 @@ import { Target, Eye, Heart, Users, Award, Clock } from "lucide-react";
 import { useLanguage } from "./LanguageContext";
 import { ImageWithFallback } from "./figma/ImageWithFallback";
 import { useActiveLocale } from "../hooks/useActiveLocale";
+import { useRouteInfo } from "../hooks/useRouteInfo";
 import { buildLocalizedPath, type PageType } from "../routing";
 
 export function AboutSection() {
   const { t } = useLanguage();
   const navigate = useNavigate();
   const { activeLocale, includeLocalePrefix } = useActiveLocale();
+  const routeInfo = useRouteInfo();
 
   const values = [
     {

--- a/src/components/MobileQuickNav.tsx
+++ b/src/components/MobileQuickNav.tsx
@@ -6,6 +6,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { smoothScroll } from "../utils/smoothScroll";
 import { buildLocalizedPath } from "../routing";
 import { useActiveLocale } from "../hooks/useActiveLocale";
+import { useRouteInfo } from "../hooks/useRouteInfo";
 
 interface MobileQuickNavProps {
   onSectionClick?: (sectionId: string) => void;
@@ -38,6 +39,7 @@ export function MobileQuickNav({ onSectionClick }: MobileQuickNavProps) {
   const { language } = useLanguage();
   const navigate = useNavigate();
   const { activeLocale, includeLocalePrefix } = useActiveLocale();
+  const routeInfo = useRouteInfo();
   const isMobile = useIsMobile();
 
   const translations: Record<


### PR DESCRIPTION
## Summary
- import the route information hook in AboutSection and MobileQuickNav
- read the current route info before comparing navigation targets

## Testing
- npm run build (fails: missing vite/react type declarations in repo)


------
https://chatgpt.com/codex/tasks/task_e_68dc541c81c08323977d43cfe4795e20