### PR TITLE
Stabilize BrowserRouter server snapshot handling

### DIFF
--- a/src/router/react-router-dom.tsx
+++ b/src/router/react-router-dom.tsx
@@ -2,9 +2,11 @@ import {
   Children,
   createContext,
   isValidElement,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useSyncExternalStore,
   type ReactNode,
 } from "react";
@@ -93,11 +95,25 @@ export function BrowserRouter({ children }: { children?: ReactNode }) {
     throw new Error("BrowserRouter can only be used in the browser");
   }
 
+  const initialLocationRef = useRef<Location | null>(null);
+  if (initialLocationRef.current === null) {
+    initialLocationRef.current = createBrowserLocation();
+  }
+
+  const getServerSnapshot = useCallback(
+    () => initialLocationRef.current as Location,
+    []
+  );
+
   const location = useSyncExternalStore(
     subscribeToHistory,
     createBrowserLocation,
-    createBrowserLocation
+    getServerSnapshot
   );
+
+  useEffect(() => {
+    initialLocationRef.current = location;
+  }, [location]);
 
   const navigator = useMemo(() => createBrowserNavigator(), []);
 


### PR DESCRIPTION
## Summary
- ensure BrowserRouter captures the initial browser location in a persistent ref
- provide a stable getServerSnapshot for useSyncExternalStore and sync the ref with updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc57f9154c8323a4df0d319303340e