### PR TITLE
Ensure LanguageProvider matches SSR language on hydration

### DIFF
--- a/src/components/LanguageContext.tsx
+++ b/src/components/LanguageContext.tsx
@@ -25,35 +25,24 @@ interface LanguageProviderProps {
   localeFromRoute?: Language;
 }
 
-function resolveStoredLanguage(): Language | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
-  const stored = window.localStorage.getItem("language");
-  if (stored === "en" || stored === "me") {
-    return stored;
-  }
-  return null;
-}
-
 export function LanguageProvider({
   children,
   initialLanguage,
   localeFromRoute,
 }: LanguageProviderProps) {
-  const [language, setLanguageState] = useState<Language>(() => {
-    if (localeFromRoute) {
-      return localeFromRoute;
+  const [language, setLanguageState] = useState<Language>(
+    () => localeFromRoute ?? initialLanguage ?? defaultLocale,
+  );
+
+  useEffect(() => {
+    if (localeFromRoute || typeof window === "undefined") {
+      return;
     }
-    const stored = resolveStoredLanguage();
-    if (stored) {
-      return stored;
+    const stored = window.localStorage.getItem("language");
+    if ((stored === "en" || stored === "me") && stored !== language) {
+      setLanguageState(stored);
     }
-    if (initialLanguage) {
-      return initialLanguage;
-    }
-    return defaultLocale;
-  });
+  }, [localeFromRoute, language]);
 
   useEffect(() => {
     if (localeFromRoute && localeFromRoute !== language) {


### PR DESCRIPTION
## Summary
- initialize the language state directly from the SSR-provided locale or default
- defer localStorage preference lookup to a client-side effect when no route locale is present
- keep persistence and document language synchronization effects intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc5d77426c8323a378c9a29ccfc3ac