### PR TITLE
Preserve persisted language preference during client hydration

### DIFF
--- a/src/entry-client.tsx
+++ b/src/entry-client.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { AppRoutes } from "./routes";
-import { defaultLocale, type Locale } from "./routing";
+import { defaultLocale, type Locale, isLocale } from "./routing";
 import "./index.css";
 
 declare global {
@@ -17,17 +17,31 @@ const container = document.getElementById("root");
 
 if (container) {
   const initialLocale = window.__INITIAL_STATE__?.locale;
-  if (initialLocale && typeof window !== "undefined") {
+  const storageKey = "language";
+
+  if (typeof window !== "undefined") {
+    let storedLocale: string | null = null;
+
     try {
-      window.localStorage.setItem("language", initialLocale);
+      storedLocale = window.localStorage.getItem(storageKey);
     } catch (error) {
-      console.warn("Unable to persist initial language", error);
+      console.warn("Unable to read persisted language", error);
     }
-  } else if (typeof window !== "undefined") {
-    try {
-      window.localStorage.setItem("language", defaultLocale);
-    } catch (error) {
-      console.warn("Unable to persist default language", error);
+
+    if (!isLocale(storedLocale)) {
+      if (initialLocale) {
+        try {
+          window.localStorage.setItem(storageKey, initialLocale);
+        } catch (error) {
+          console.warn("Unable to persist initial language", error);
+        }
+      } else {
+        try {
+          window.localStorage.setItem(storageKey, defaultLocale);
+        } catch (error) {
+          console.warn("Unable to persist default language", error);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- read the previously stored language preference before updating the client storage
- only persist the initial or default locale when no valid value is found, keeping user selections intact
- keep existing storage failure logging while adding a warning for read errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcd95a9b3883239ad4b42ea4f2378f