### PR TITLE
Pass footer year through initial state context

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,10 +2,14 @@ import { Separator } from "./ui/separator";
 import { Facebook, Instagram, Linkedin, Mail, Phone, MapPin } from "lucide-react";
 import { useLanguage } from "./LanguageContext";
 
-export function Footer() {
+interface FooterProps {
+  initialYear?: string;
+}
+
+export function Footer({ initialYear }: FooterProps) {
   const { t } = useLanguage();
 
-  const currentYear = new Date().getFullYear();
+  const displayYear = initialYear ?? "2024";
 
   const services = ["Web dizajn i razvoj", "SEO optimizacija", "Upravljanje društvenim mrežama", "Brendiranje", "Digitalna strategija"];
 
@@ -160,7 +164,7 @@ export function Footer() {
         {/* Bottom Footer */}
         <div className="flex flex-col md:flex-row justify-between items-center gap-4">
           <p className="text-gray-400 text-sm">
-            © {currentYear} BDigital. {t("footer.rights")}
+            © {displayYear} BDigital. {t("footer.rights")}
           </p>
           <div className="flex gap-6 text-sm text-gray-400">
             <a href="#" className="hover:text-bdigital-cyan transition-colors duration-200">

--- a/src/components/InitialStateContext.tsx
+++ b/src/components/InitialStateContext.tsx
@@ -1,0 +1,22 @@
+import { createContext, useContext, type ReactNode } from "react";
+import type { Locale } from "../routing";
+
+export interface InitialAppState {
+  locale?: Locale;
+  footerYear?: number;
+}
+
+const InitialStateContext = createContext<InitialAppState | undefined>(undefined);
+
+interface InitialStateProviderProps {
+  value: InitialAppState | undefined;
+  children: ReactNode;
+}
+
+export function InitialStateProvider({ value, children }: InitialStateProviderProps) {
+  return <InitialStateContext.Provider value={value}>{children}</InitialStateContext.Provider>;
+}
+
+export function useInitialState() {
+  return useContext(InitialStateContext);
+}

--- a/src/entry-client.tsx
+++ b/src/entry-client.tsx
@@ -2,21 +2,21 @@ import { StrictMode } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { AppRoutes } from "./routes";
-import { defaultLocale, type Locale, isLocale } from "./routing";
+import { defaultLocale, isLocale } from "./routing";
+import { InitialStateProvider, type InitialAppState } from "./components/InitialStateContext";
 import "./index.css";
 
 declare global {
   interface Window {
-    __INITIAL_STATE__?: {
-      locale?: Locale;
-    };
+    __INITIAL_STATE__?: InitialAppState;
   }
 }
 
 const container = document.getElementById("root");
 
 if (container) {
-  const initialLocale = window.__INITIAL_STATE__?.locale;
+  const initialState: InitialAppState | undefined = window.__INITIAL_STATE__;
+  const initialLocale = initialState?.locale;
   const storageKey = "language";
 
   if (typeof window !== "undefined") {
@@ -48,9 +48,11 @@ if (container) {
   hydrateRoot(
     container,
     <StrictMode>
-      <BrowserRouter>
-        <AppRoutes />
-      </BrowserRouter>
+      <InitialStateProvider value={initialState}>
+        <BrowserRouter>
+          <AppRoutes />
+        </BrowserRouter>
+      </InitialStateProvider>
     </StrictMode>
   );
 }

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -5,6 +5,7 @@ import { AppRoutes } from "./routes";
 import { SITE_BASE_URL } from "./config/site";
 import { getSeoMetadata } from "./config/seo-meta";
 import { locales, parsePathname } from "./routing";
+import { InitialStateProvider, type InitialAppState } from "./components/InitialStateContext";
 import {
   STRUCTURED_DATA_ELEMENT_ID,
   buildCanonicalCluster,
@@ -31,6 +32,7 @@ export interface RenderResult {
   htmlLang: string;
   initialState: {
     locale: string;
+    footerYear?: number;
   };
 }
 
@@ -39,18 +41,23 @@ export interface RenderOptions {
 }
 
 export function render(url: string, options: RenderOptions = {}): RenderResult {
+  const requestUrl = new URL(url, SITE_BASE_URL);
+  const { locale, page, hasLocalePrefix } = parsePathname(requestUrl.pathname);
+  const footerYear = new Date().getFullYear();
+  const initialState: InitialAppState = { locale, footerYear };
+
   const app = (
     <StrictMode>
-      <StaticRouter location={url}>
-        <AppRoutes />
-      </StaticRouter>
+      <InitialStateProvider value={initialState}>
+        <StaticRouter location={url}>
+          <AppRoutes />
+        </StaticRouter>
+      </InitialStateProvider>
     </StrictMode>
   );
 
   const html = renderToString(app);
 
-  const requestUrl = new URL(url, SITE_BASE_URL);
-  const { locale, page, hasLocalePrefix } = parsePathname(requestUrl.pathname);
   const canonicalCluster = buildCanonicalCluster({
     currentUrl: requestUrl,
     hasLocalePrefix,
@@ -128,7 +135,7 @@ export function render(url: string, options: RenderOptions = {}): RenderResult {
     head,
     preloadLinks,
     htmlLang: locale,
-    initialState: { locale },
+    initialState,
   };
 }
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -17,6 +17,7 @@ import { StrategyPage } from "./components/services/StrategyPage";
 import { ServiceInquiryForm } from "./components/ServiceInquiryForm";
 import { FreeConsultationPage } from "./components/FreeConsultationPage";
 import { MobileQuickNav } from "./components/MobileQuickNav";
+import { useInitialState } from "./components/InitialStateContext";
 import { getSeoMetadata } from "./config/seo-meta";
 import { SITE_BASE_URL } from "./config/site";
 import {
@@ -183,6 +184,8 @@ function HomePage() {
 function AppLayout() {
   const location = useLocation();
   const isHome = parsePathname(location.pathname).page === "home";
+  const initialState = useInitialState();
+  const footerYear = initialState?.footerYear ? String(initialState.footerYear) : undefined;
 
   return (
     <div className="min-h-screen bg-white">
@@ -191,7 +194,7 @@ function AppLayout() {
         <Outlet />
       </main>
       {isHome && <MobileQuickNav />}
-      {isHome && <Footer />}
+      {isHome && <Footer initialYear={footerYear} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add an initial state context to share server-provided values with the app tree
- pass the precomputed footer year from the server through the new provider and into the footer component
- stop computing the current year inside the footer render and fall back to a static label when missing

## Testing
- `npm run build` *(fails: existing TypeScript configuration cannot resolve React and related modules in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcded4a0e4832393feb02a9d87db42