### PR TITLE
Make locale required in initial app state context

### DIFF
--- a/src/components/InitialStateContext.tsx
+++ b/src/components/InitialStateContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, type ReactNode } from "react";
 import type { Locale } from "../routing";
 
 export interface InitialAppState {
-  locale?: Locale;
+  locale: Locale;
   footerYear?: number;
 }
 


### PR DESCRIPTION
## Summary
- make the `locale` property mandatory in `InitialAppState`

## Testing
- `npm run build` *(fails: missing TypeScript definition packages in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dce610d25483239edf5a41a14f3914