### PR TITLE
Add HTML MIME type for static asset responses

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -119,6 +119,8 @@ function getMimeType(filePath: string) {
       return "application/javascript";
     case ".css":
       return "text/css";
+    case ".html":
+      return "text/html";
     case ".json":
       return "application/json";
     case ".ico":


### PR DESCRIPTION
### Motivation
- Ensure static `.html` files are served with the correct `Content-Type` header so browsers render pages correctly.
- Fix an oversight where HTML files could be returned with the default `text/plain` MIME type.

### Description
- Added handling for the `.html` extension in `getMimeType` inside `server.ts` to return `text/html`.
- This change causes `tryServeStatic` to set `Content-Type: text/html` for served HTML files.
- Only `server.ts` was modified to map `.html` -> `text/html`.

### Testing
- Ran `npm test` (which runs `tsc -p tsconfig.tests.json` and the SEO regression checks), and the tests passed.
- Ran `npm run lint`, which failed due to a missing dev dependency (`@eslint/js`) unrelated to the runtime change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a7ab4849883238b873cbb2939b198)